### PR TITLE
Add default for /engines/active-engine/damage_allowed

### DIFF
--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -733,6 +733,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <carb_icing_allowed type="bool">false</carb_icing_allowed>
             <auto-start type="bool">false</auto-start>
             <complex-engine-procedures type="bool">false</complex-engine-procedures>
+            <damage_allowed>false</damage_allowed>
         </active-engine>
 
         <!-- Following properties are part of a static list of properties


### PR DESCRIPTION
With liberal use of rebasing and force pushing I managed to clean this up for you 😉 
Hope this is satisfactory.