### PR TITLE
Slight modifications and safeguards to exiting amphibious tutorials

### DIFF
--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -304,6 +304,7 @@ var switches_save_state = func {
         setprop("/controls/lighting/dome-white-norm", 1.0);
         setprop("/controls/lighting/dome-norm", 0.0);
         setprop("/controls/lighting/gps-norm", 0.0);
+        setprop("/controls/lighting/gearled", 0);
         setprop("/controls/gear/water-rudder", 0);
         setprop("/controls/gear/water-rudder-down", 0);
         setprop("/sim/model/c172p/brake-parking", 1);

--- a/Tutorials/amphibious-landing.xml
+++ b/Tutorials/amphibious-landing.xml
@@ -215,7 +215,7 @@ Pay attention to the heading bug on landing it will approximate the mooring posi
             <pitch-offset-deg>-12</pitch-offset-deg>
             <roll-offset-deg>0.0</roll-offset-deg>
             <x-offset-m>-0.21</x-offset-m>
-            <y-offset-m>0.19</y-offset-m>
+            <y-offset-m>0.23</y-offset-m>
             <field-of-view>73.6</field-of-view>
         </view>
     </step>
@@ -263,7 +263,7 @@ Pay attention to the heading bug on landing it will approximate the mooring posi
             </condition>
         </error>
         <error>
-            <message>Your gear must be down to take off.</message>
+            <message>Your gear must be down to take off Shift+[g].</message>
             <condition>
                 <equals>
                     <property>/controls/gear/gear-down</property>
@@ -345,7 +345,7 @@ Pay attention to the heading bug on landing it will approximate the mooring posi
             </condition>
         </error>
         <error>
-            <message>Raise your landing gear now.</message>
+            <message>Raise your landing gear now [g].</message>
             <condition>
                 <equals>
                     <property>/controls/gear/gear-down</property>
@@ -459,10 +459,16 @@ Pay attention to the heading bug on landing it will approximate the mooring posi
 
         <exit>
             <condition>
-                <greater-than>
-                    <property>/position/longitude-deg</property>
-                    <value>-157.9550502</value>
-                </greater-than>
+                <or>
+                    <greater-than>
+                        <property>/position/longitude-deg</property>
+                        <value>-157.9550502</value>
+                    </greater-than>
+                    <greater-than>
+                        <property>/sim/tutorials/targets/mooring</property>
+                        <value>5240</value>
+                    <greater-than>
+                </or>
             </condition>
         </exit>
     </step>
@@ -530,6 +536,10 @@ Pay attention to the heading bug on landing it will approximate the mooring posi
                         <property>/controls/flight/flaps</property>
                         <value>0</value>
                     </greater-than>
+                    <less-than>
+                       <property>/velocities/groundspeed-kt</property>
+                       <value>70</value>
+                    </less-than>
                 </and>
             </condition>
         </exit>
@@ -548,13 +558,9 @@ Pay attention to the heading bug on landing it will approximate the mooring posi
             </condition>
         </error>
         <error>
-            <message>Raise pontoon landing gear.</message>
+            <message>Raise pontoon landing gear [g].</message>
             <condition>
                 <and>
-                    <greater-than>
-                        <property>/velocities/groundspeed-kt</property>
-                        <value>10</value>
-                    </greater-than>
                     <less-than>
                        <property>/velocities/groundspeed-kt</property>
                        <value>70</value>

--- a/Tutorials/amphibious-night.xml
+++ b/Tutorials/amphibious-night.xml
@@ -2,22 +2,22 @@
 
 <PropertyList>
 
-    <name>Amphibious Takeoff</name>
+    <name>Amphibious Night</name>
 
     <description>
-This tutorial starts from Hilo International Airport (PHNL), a seaplane airfield located in Oahu's Keehi Lagoon, Honolulu, Hawaii in clear, still, weather.
-    
+This tutorial starts from Hilo International Airport (PHNL), a seaplane airfield located in Oahu's Keehi Lagoon, Honolulu, Hawaii in clear, still, weather at night.
+
 By now you should be proficient in the preflight checklist, startup proceedures, determining the appropriate taxiing route to the desired runway, takeoff, flying a pattern and landing.
 
-You will taxi and takeoff from water runway 4W at PHNL on heading 043, climb at 600 feet per minute leveling off at 1000 ft., turn left 180 degree onto final heading 223 to land at PHNL and complete the tutorial.
+You will taxi and takeoff from water runway 4W at PHNL on heading 043, climb at 600 feet per minute leveling off at 1000 ft., turn left 180 degree onto heading 223 to touch-n-go at PHNL on heading 223, climb at 600 feet per minute leveling off at 1000 ft., turn left 180 degree onto final heading 043 and landing on water runway 4W at PHNL.
 
 Water runway 4W/22W is parallel and immediately adjacent to land based runway 4R/22L.
 
-Pay attention to the heading bug on taxiing it will approximate the threshold position of runway 4W.
+Pay attention to the heading bug on taxiing it will approximate the threshold position of runway 4W and on landing it will approximate the mooring position..
     </description>
 
     <audio-dir>Tutorials/amphibious</audio-dir>
-    <timeofday>morning</timeofday>
+    <timeofday>midnight</timeofday>
 
     <presets>
         <airport-id>PHNL</airport-id>
@@ -41,6 +41,11 @@ Pay attention to the heading bug on taxiing it will approximate the threshold po
             <latitude-deg>21.31335723</latitude-deg>
             <longitude-deg>-157.9157261</longitude-deg>
         </runway>
+        <mooring>
+            <!-- Mooring location -->
+            <latitude-deg>21.31670172</latitude-deg>
+            <longitude-deg>-157.9124451</longitude-deg>
+        </mooring>
     </targets>
 
     <step>
@@ -95,10 +100,10 @@ Pay attention to the heading bug on taxiing it will approximate the threshold po
             <property>/instrumentation/adf/frequencies/selected-khz</property>
             <value>242</value> <!-- EWABE NDB -->
         </set>
-        <set>
+        <!--set>
             <property>/environment/weather-scenario</property>
             <value>Fair weather</value>
-        </set>
+        </set-->
         <set>
             <property>instrumentation/altimeter/setting-inhg</property>
             <value>29.92</value>
@@ -377,6 +382,65 @@ Pay attention to the heading bug on taxiing it will approximate the threshold po
                     <property>/controls/gear/water-rudder</property>
                     <value>1</value>
                 </equals>
+            </condition>
+        </exit>
+    </step>
+
+    <step>
+        <message>Turn navagation lights on.</message>
+
+        <wait>10</wait>
+
+        <error>
+            <message>Turn taxi light on.</message>
+            <condition>
+                <not>
+                    <property>/controls/lighting/taxi-light</property>
+                </not>
+            </condition>
+        </error>
+        <error>
+            <message>Turn landing light on.</message>
+            <condition>
+                <not>
+                    <property>/controls/lighting/landing-lights</property>
+                </not>
+            </condition>
+        </error>
+        <error>
+            <message>Turn nav light on.</message>
+            <condition>
+                <not>
+                    <property>/controls/lighting/nav-lights</property>
+                </not>
+            </condition>
+        </error>
+        <error>
+            <message>Turn beacon light on.</message>
+            <condition>
+                <not>
+                    <property>/controls/lighting/beacon</property>
+                </not>
+            </condition>
+        </error>
+        <error>
+            <message>Turn strobe light on.</message>
+            <condition>
+                <not>
+                    <property>/controls/lighting/strobe</property>
+                </not>
+            </condition>
+        </error>
+   
+        <exit>
+            <condition>
+                <and>
+                    <property>/controls/lighting/taxi-light</property>
+                    <property>/controls/lighting/landing-lights</property>
+                    <property>/controls/lighting/nav-lights</property>
+                    <property>/controls/lighting/beacon</property>
+                    <property>/controls/lighting/strobe</property>
+                </and>
             </condition>
         </exit>
     </step>
@@ -867,20 +931,607 @@ Pay attention to the heading bug on taxiing it will approximate the threshold po
     </step>
 
     <step>
-        <message>Execute approach and landing.</message>
+        <message>Execute approach and touch-n-go.</message>
+
+        <exit>
+            <condition>
+                <and>
+                    <property>/fdm/jsbsim/gear/unit[19]/WOW</property>
+                    <property>/fdm/jsbsim/gear/unit[20]/WOW</property>
+                    <property>/fdm/jsbsim/gear/unit[21]/WOW</property>
+                    <property>/fdm/jsbsim/gear/unit[22]/WOW</property>
+                </and>
+            </condition>
+        </exit>
+    </step>
+
+        <step>
+        <message>Takeoff course of 223, retact flaps, smoothly apply full power, control direction using rudder or differential braking.</message>
+
+        <error>
+            <message>Retract flaps.</message>
+            <condition>
+                <greater-than>
+                    <property>/controls/flight/flaps</property>
+                    <value>0.0</value>
+                </greater-than>
+            </condition>
+        </error>
+        <error>
+            <message>Apply full throttle for takeoff.</message>
+            <condition>
+                <less-than>
+                    <property>/controls/engines/current-engine/throttle</property>
+                    <value>0.95</value>
+                </less-than>
+            </condition>
+        </error>
+
+            <property>/controls/flight/flaps</property>
+            <value>0.0</value>
+
+        <exit>
+            <condition>
+                <greater-than>
+                    <property>/velocities/airspeed-kt</property>
+                    <value>5.0</value>
+                </greater-than>
+                <equals>
+                    <property>/controls/flight/flaps</property>
+                    <value>0.0</value>
+                </equals>
+            </condition>
+        </exit>
+    </step>
+
+    <step>
+        <message>Let the aircraft lift off at 65 knots, climb straight out on heading 223, 600 feet per minute.</message>
+
+        <exit>
+            <condition>
+                <and>
+                    <greater-than>
+                        <property>/instrumentation/vertical-speed-indicator/indicated-speed-fpm</property>
+                        <value>300</value>
+                    </greater-than>
+                    <less-than>
+                        <property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+                        <value>238</value>
+                    </less-than>
+                    <greater-than>
+                        <property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+                        <value>208</value>
+                    </greater-than>
+                </and>
+            </condition>
+        </exit>
+    </step>
+
+    <step>
+        <message>Continue your climb on heading 223 at 600 feet per minute to 1000 feet.</message>
+
+        <error>
+            <message>You are heading too far left, turn right slightly to heading 223.</message>
+            <condition>
+                <less-than>
+                    <property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+                    <value>208</value>
+                </less-than>
+            </condition>
+        </error>
+        <error>
+            <message>You are heading too far right, turn left slightly to heading 223.</message>
+            <condition>
+                <greater-than>
+                    <property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+                    <value>238</value>
+                </greater-than>
+            </condition>
+        </error>
+        <error>
+            <message>Turn avionics system power switch on.</message>
+            <condition>
+                <equals>
+                    <property>/controls/switches/master-avionics</property>
+                    <value>0</value>
+                </equals>
+            </condition>
+        </error>
+        <error>
+            <message>Raise your landing gear now [g].</message>
+            <condition>
+                <equals>
+                    <property>/controls/gear/gear-down</property>
+                    <value>1</value>
+                </equals>
+            </condition>
+        </error>
+
+        <exit>
+            <condition>
+                <and>
+                    <greater-than>
+                        <property>/instrumentation/altimeter/indicated-altitude-ft</property>
+                        <value>900</value>
+                    </greater-than>
+                    <less-than>
+                        <property>/instrumentation/altimeter/indicated-altitude-ft</property>
+                        <value>1100</value>
+                    </less-than>
+                    <less-than>
+                        <property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+                        <value>238</value>
+                    </less-than>
+                    <greater-than>
+                        <property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+                        <value>208</value>
+                    </greater-than>
+                    <equals>
+                        <property>/controls/gear/gear-down</property>
+                        <value>0</value>
+                    </equals>
+                </and>
+            </condition>
+        </exit>
+    </step>
+
+    <step>
+        <message>Level off between 900 and 1100 feet.</message>
+
+        <error>
+            <message>You are too low</message>
+            <condition>
+                <less-than>
+                    <property>/instrumentation/altimeter/indicated-altitude-ft</property>
+                    <value>900</value>
+                </less-than>
+            </condition>
+        </error>
+        <error>
+            <message>You are too high</message>
+            <condition>
+                <greater-than>
+                    <property>/instrumentation/altimeter/indicated-altitude-ft</property>
+                    <value>1100</value>
+                </greater-than>
+            </condition>
+        </error>
+        <error>
+            <message>You are heading too far left, turn right slightly to heading 223.</message>
+            <condition>
+                <less-than>
+                    <property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+                    <value>208</value>
+                </less-than>
+            </condition>
+        </error>
+        <error>
+            <message>You are heading too far right, turn left slightly to heading 223.</message>
+            <condition>
+                <greater-than>
+                    <property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+                    <value>238</value>
+                </greater-than>
+            </condition>
+        </error>
+
+        <exit>
+            <condition>
+                <and>
+                    <greater-than>
+                        <property>/instrumentation/altimeter/indicated-altitude-ft</property>
+                        <value>900</value>
+                    </greater-than>
+                    <less-than>
+                        <property>/instrumentation/altimeter/indicated-altitude-ft</property>
+                        <value>1100</value>
+                    </less-than>
+                    <less-than>
+                        <property>instrumentation/vertical-speed-indicator/indicated-speed-fpm</property>
+                        <value>300</value>
+                    </less-than>
+                    <greater-than>
+                        <property>instrumentation/vertical-speed-indicator/indicated-speed-fpm</property>
+                        <value>-300</value>
+                    </greater-than>
+                    <greater-than>
+                        <property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+                        <value>207</value>
+                    </greater-than>
+                    <less-than>
+                        <property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+                        <value>247</value>
+                    </less-than>
+                </and>
+
+            </condition>
+        </exit>
+    </step>
+    <step>
+        <message>Continue outbound heading 223 at 1000 feet.</message>
+
+        <exit>
+            <condition>
+                <or>
+                    <greater-than>
+                        <property>/position/longitude-deg</property>
+                        <value>-157.9550502</value>
+                    </greater-than>
+                    <greater-than>
+                        <property>/sim/tutorials/targets/mooring</property>
+                        <value>5240</value>
+                    <greater-than>
+                </or>
+            </condition>
+        </exit>
+    </step>
+
+    <step>
+        <message>Execute a 180 degree left turn onto final heading 043, line up with water runway 4W at PHNL in Keehi Lagoon.</message>
+
+        <set>
+            <property>/autopilot/settings/heading-bug-deg</property>
+            <value>50</value>
+        </set>
+
+        <exit>
+            <condition>
+                <and>
+                    <greater-than>
+                        <property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+                        <value>28</value>
+                    </greater-than>
+                    <less-than>
+                        <property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+                        <value>58</value>
+                    </less-than>
+                </and>
+            </condition>
+        </exit>
+    </step>
+
+    <step>
+        <message>Execute power and flap regime for landing.</message>
+
+        <error>
+            <message>Check throttle.</message>
+            <condition>
+                <greater-than>
+                    <property>/controls/engines/current-engine/throttle</property>
+                    <value>0.85</value>
+                </greater-than>
+            </condition>
+        </error>
+       <error>
+            <message>Set some flaps at appropriate speed.</message>
+            <condition>
+                <and>
+                    <less-than>
+                        <property>/controls/flight/flaps</property>
+                        <value>0.3</value>
+                    </less-than>
+                    <less-than>
+                        <property>/velocities/airspeed-kt</property>
+                        <value>110</value>
+                    </less-than>
+                </and>
+            </condition>
+        </error>
+
+        <exit>
+            <condition>
+                <and>
+                    <less-than>
+                        <property>/controls/engines/current-engine/throttle</property>
+                        <value>0.9</value>
+                    </less-than>
+                    <greater-than>
+                        <property>/controls/flight/flaps</property>
+                        <value>0</value>
+                    </greater-than>
+                    <less-than>
+                       <property>/velocities/groundspeed-kt</property>
+                       <value>70</value>
+                    </less-than>
+                </and>
+            </condition>
+        </exit>
+    </step>
+
+    <step>
+        <message>Check gear advisory.</message>
+
+        <error>
+            <message>Turn avionics system power switch on.</message>
+            <condition>
+                <equals>
+                    <property>/controls/switches/master-avionics</property>
+                    <value>0</value>
+                </equals>
+            </condition>
+        </error>
+        <error>
+            <message>Raise pontoon landing gear [g].</message>
+            <condition>
+                <and>
+                    <less-than>
+                       <property>/velocities/groundspeed-kt</property>
+                       <value>70</value>
+                    </less-than>
+                    <equals>
+                        <property>/controls/gear/gear-down</property>
+                        <value>1</value>
+                    </equals>
+                </and>
+            </condition>
+        </error>
+        <exit>
+            <condition>
+                <equals>
+                    <property>/controls/gear/gear-down</property>
+                    <value>0</value>
+                </equals>
+            </condition>
+        </exit>
+    </step>
+
+    <step>
+        <message>Execute landing.</message>
+
+        <error>
+            <message>Check throttle.</message>
+            <condition>
+                <greater-than>
+                    <property>/controls/engines/current-engine/throttle</property>
+                    <value>0.65</value>
+                </greater-than>
+            </condition>
+        </error>
+        <error>
+            <message>Continue approach then gently touch down in the water.</message>
+            <condition>
+                <equals>
+                    <property>/fdm/jsbsim/hydro/active-norm</property>
+                    <value>0</value>
+                </equals>
+            </condition>
+        </error>
+
+        <exit>
+            <condition>
+                <equals>
+                    <property>/fdm/jsbsim/hydro/active-norm</property>
+                    <value>1</value>
+                </equals>
+            </condition>
+        </exit>
+    </step>
+
+    <step>
+        <message>Lower water rudders for better control Shift+[r].</message>
+
+        <error>
+            <message>Lower water rudders Shift+[r].</message>
+            <condition>
+                <equals>
+                    <property>/controls/gear/water-rudder</property>
+                    <value>0</value>
+                </equals>
+            </condition>
+        </error>
+        <error>
+            <message>Settle back into the water.</message>
+            <condition>
+                <equals>
+                    <property>/fdm/jsbsim/hydro/active-norm</property>
+                    <value>0</value>
+                </equals>
+            </condition>
+        </error>
+
+        <exit>
+            <and>
+                <condition>
+                    <less-than>
+                        <property>/velocities/groundspeed-kt</property>
+                        <value>20.0</value>
+                    </less-than>
+                </condition>
+                <condition>
+                    <equals>
+                        <property>/controls/gear/water-rudder</property>
+                        <value>1</value>
+                    </equals>
+                </condition>
+                <condition>
+                    <equals>
+                        <property>/fdm/jsbsim/hydro/active-norm</property>
+                        <value>1</value>
+                    </equals>
+                </condition>
+            </and>
+        </exit>
+    </step>
+
+    <step>
+        <message>Taxi off of runway following your heading bug towards the mooring location.</message>
+
+        <nasal>
+            <script>
+                setprop("/autopilot/settings/heading-bug-deg", getprop("/sim/tutorials/targets/mooring/heading-deg"));
+            </script>
+        </nasal>
+
+        <error>
+            <message>You're off course. To reach the mooring location turn to the left following your heading bug.</message>
+            <nasal>
+                <script>
+                    setprop("/autopilot/settings/heading-bug-deg", getprop("/sim/tutorials/targets/mooring/heading-deg"));
+                </script>
+            </nasal>
+            <condition>
+                <less-than>
+                    <property>/sim/tutorials/targets/mooring/direction-deg</property>
+                    <value>-20</value>
+                </less-than>
+            </condition>
+        </error>
+        <error>
+            <message>You're off course. To reach the mooring location turn to the right following your heading bug.</message>
+            <nasal>
+                <script>
+                    setprop("/autopilot/settings/heading-bug-deg", getprop("/sim/tutorials/targets/mooring/heading-deg"));
+                </script>
+            </nasal>
+            <condition>
+                <greater-than>
+                    <property>/sim/tutorials/targets/mooring/direction-deg</property>
+                    <value>20</value>
+                </greater-than>
+            </condition>
+        </error>
+
+        <exit>
+            <condition>
+                <and>
+                    <less-than>
+                        <property>/sim/tutorials/targets/mooring/direction-deg</property>
+                        <value>20</value>
+                    </less-than>
+                    <greater-than>
+                        <property>/sim/tutorials/targets/mooring/direction-deg</property>
+                        <value>-20</value>
+                    </greater-than>
+                </and>
+            </condition>
+        </exit>
+    </step>
+
+    <step>
+        <message>Continue taxiing towards mooring location following your heading bug.</message>
 
         <exit>
             <condition>
                 <less-than>
-                    <property>/velocities/groundspeed-kt</property>
-                    <value>10.0</value>
+                    <property>/sim/tutorials/targets/mooring/distance-m</property>
+                    <value>120.0</value>
                 </less-than>
             </condition>
         </exit>
     </step>
 
     <step>
-        <message>Congratulations on successfully executing a water taxi and take off, then following a pattern to a ground landing.</message>
+        <message>Prepare to set mooring anchor by immediately turning into the wind by following the heading bug, shut off the engine and open the "Mooring Parameters" menu.</message>
+
+        <nasal>
+            <script>
+                setprop("/autopilot/settings/heading-bug-deg", getprop("/environment/wind-from-heading-deg"));
+            </script>
+        </nasal>
+
+        <error>
+            <message>Face into the wind (follow the heading bug) and shut off your engine.</message>
+            <nasal>
+                <script>
+                    setprop("/autopilot/settings/heading-bug-deg", getprop("/environment/wind-from-heading-deg"));
+                </script>
+            </nasal>
+            <condition>
+                <equals>
+                    <property>/engines/active-engine/running</property>
+                    <value>1</value>
+                </equals>
+            </condition>
+        </error>
+
+        <exit>
+            <condition>
+                <equals>
+                    <property>/engines/active-engine/running</property>
+                    <value>0</value>
+                </equals>
+            </condition>
+        </exit>
+    </step>
+
+    <step>
+        <message>Get ready to drop the mooring anchor.</message>
+
+        <nasal>
+            <script>
+                setprop("/autopilot/settings/heading-bug-deg", getprop("/environment/wind-from-heading-deg"));
+            </script>
+        </nasal>
+
+        <error>
+            <message>Face into the wind following your heading bug or using info from the "Mooring Parameters" menu, [Set] the mooring anchor under "Mooring Parameters".</message>
+            <condition>
+                <equals>
+                    <property>/controls/mooring/anchor</property>
+                    <value>0</value>
+                </equals>
+            </condition>
+        </error>
+        <error>
+            <message>Can't anchor with with forward speed greater than 7.</message>
+            <condition>
+                <greater-than>
+                    <property>/fdm/jsbsim/hydro/vbx-fps</property>
+                    <value>7</value>
+                </greater-than>
+            </condition>
+        </error>
+        <error>
+            <message>If needed start engine briefly to gain momentum.</message>
+            <condition>
+                <less-than>
+                    <property>/fdm/jsbsim/hydro/vbx-fps</property>
+                    <value>3</value>
+                </less-than>
+            </condition>
+        </error>
+        <error>
+            <message>Kill engine and face into the wind using momentum.</message>
+            <nasal>
+                <script>
+                    setprop("/autopilot/settings/heading-bug-deg", getprop("/environment/wind-from-heading-deg"));
+                </script>
+            </nasal>
+            <condition>
+                <equals>
+                    <property>/engines/active-engine/running</property>
+                    <value>1</value>
+                </equals>
+            </condition>
+        </error>
+        <error>
+            <message>Wind speed is too great to set mooring anchor.</message>
+            <condition>
+                <greater-than>
+                    <property>/environment/windsock/wind-speed-kt</property>
+                    <value>40</value>
+                </greater-than>
+            </condition>
+        </error>
+
+        <exit>
+            <condition>
+                <or>
+                    <greater-than>
+                        <property>/environment/windsock/wind-speed-kt</property>
+                        <value>40</value>
+                    </greater-than>
+                    <equals>
+                        <property>/controls/mooring/anchor</property>
+                        <value>1</value>
+                    </equals>
+                </or>
+            </condition>
+        </exit>
+    </step>
+
+    <step>
+        <message>Congratulations on successfully executing a water taxi and take off, ground touch and go, water landing and mooring anchor all at night.</message>
     </step>
 
 </PropertyList>

--- a/Tutorials/c172-tutorials.xml
+++ b/Tutorials/c172-tutorials.xml
@@ -15,5 +15,6 @@
     <tutorial include="engine-failure.xml"/>
     <tutorial include="amphibious-takeoff.xml"/>
     <tutorial include="amphibious-landing.xml"/>
+    <tutorial include="amphibious-night.xml"/>
 
 </PropertyList>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -305,6 +305,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <path>/controls/mooring/automatic</path>
             <path>/controls/lighting/dome-white-norm</path>
             <path>/controls/lighting/dome-norm</path>
+            <path>/controls/lighting/gearled</path>
         </aircraft-data>
 
         <current-view>
@@ -595,11 +596,13 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <radio-norm type="double">0.0</radio-norm>
             <dome-white-norm type="double">1.0</dome-white-norm>
             <gps-norm type="double">0.0</gps-norm>
+            <gearled type="bool">true</gearled>
         </lighting>
         <gear>
             <water-rudder type="bool">0</water-rudder>
             <water-rudder-down type="double">0</water-rudder-down>
             <brake-parking type="bool">true</brake-parking>
+
         </gear>
         <mooring>
             <automatic type="bool">false</automatic>


### PR DESCRIPTION
@gilbertohasnofb forgive me but there were too many small issues for me to let it go. The modifications to the landing and takeoff tutorials are as follows. There is also a couple related to the gear panel toggle switch.

Gear panel dim toggle switch needed a default value in -set.xml or it glitch at night when first used.
It also needed to be added to saved aircraft-data as well as nasal save switch state.

The landing and takeoff tutorial check point for distance to make the 180 was really buggy if your line was off course at all from the original. It was using only lat or lon and that wasn't perfectly perpendicular so it was buggy. I added distance to either mooring target or runway target so it is pretty much foolproof now.
Also there was some timing issues with the check gear advisory and that is much better now and makes sense as it comes on about the time you need to make changes to your gear.
For consistency I also added the Shift+[g] and [g] to the gear raising messages.

I added a night tutorial, it is the two day tutorials combined into one with a land runway touch and go in the middle. It is a really fun challenge. It also adds the nighttime dimension and shows off all the lighting, interior and exterior. It is really cool, you see at various points lots of AI taxiing around and taking off.

I think that is all.

Do you want me to also create an issue for this? I really think it may pass without any modifications.