### PR TITLE
Correct Astro Tech Digital Clock name in aircraft dialog

### DIFF
--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -394,7 +394,7 @@
             
             <checkbox>
                 <halign>left</halign>
-                <label>Show Aero Tech LC2 Digital Clock</label>
+                <label>Show Astro Tech LC2 Digital Clock</label>
                 <property>/sim/model/c172p/digitalclock-visible</property>
                 <live>true</live>
                 <binding>


### PR DESCRIPTION
Fixes #1190 