### PR TITLE
Add integral lighting to panel instruments for default renderer

### DIFF
--- a/Models/Effects/interior/c172p-interior-radiance.eff
+++ b/Models/Effects/interior/c172p-interior-radiance.eff
@@ -20,10 +20,10 @@
         <light-radius type="float">13</light-radius>
         <irradiance-map-type type="int">2</irradiance-map-type>
         <irradiance-map-strength type="float">.2</irradiance-map-strength>
-        <residual-ambience-r type="float"><use>/sim/model/c172p/lighting/rgb-ra-r-factor</use></residual-ambience-r>
+        <!--residual-ambience-r type="float"><use>/sim/model/c172p/lighting/rgb-ra-r-factor</use></residual-ambience-r>
         <residual-ambience-g type="float"><use>/sim/model/c172p/lighting/rgb-ra-g-factor</use></residual-ambience-g>
         <residual-ambience-b type="float"><use>/sim/model/c172p/lighting/rgb-ra-b-factor</use></residual-ambience-b>
         <ra-irradiance-map-type type="int">0</ra-irradiance-map-type>
-        <ra-irradiance-map-strength type="float">1</ra-irradiance-map-strength>
+        <ra-irradiance-map-strength type="float">1</ra-irradiance-map-strength-->
     </parameters>
 </PropertyList>

--- a/Models/Effects/interior/c172p-interior.eff
+++ b/Models/Effects/interior/c172p-interior.eff
@@ -23,10 +23,10 @@
         <light-radius type="float">13</light-radius>
         <irradiance-map-type type="int">2</irradiance-map-type>
         <irradiance-map-strength type="float">.2</irradiance-map-strength>
-        <residual-ambience-r type="float"><use>/sim/model/c172p/lighting/rgb-ra-r-factor</use></residual-ambience-r>
+        <!--residual-ambience-r type="float"><use>/sim/model/c172p/lighting/rgb-ra-r-factor</use></residual-ambience-r>
         <residual-ambience-g type="float"><use>/sim/model/c172p/lighting/rgb-ra-g-factor</use></residual-ambience-g>
         <residual-ambience-b type="float"><use>/sim/model/c172p/lighting/rgb-ra-b-factor</use></residual-ambience-b>
         <ra-irradiance-map-type type="int">0</ra-irradiance-map-type>
-        <ra-irradiance-map-strength type="float">1</ra-irradiance-map-strength>
+        <ra-irradiance-map-strength type="float">1</ra-irradiance-map-strength-->
     </parameters>
 </PropertyList>

--- a/Models/Interior/Panel/Instruments/AI/AI.xml
+++ b/Models/Interior/Panel/Instruments/AI/AI.xml
@@ -25,6 +25,7 @@
         <object-name>Pitch</object-name>
         <object-name>Roll</object-name>
         <object-name>RollReference</object-name>
+        <object-name>Case</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>

--- a/Models/Interior/Panel/Instruments/AI/AI.xml
+++ b/Models/Interior/Panel/Instruments/AI/AI.xml
@@ -19,19 +19,24 @@
         <object-name>Case</object-name>
     </effect>
 
-    <!--animation>
+    <animation>
         <type>material</type>
         <object-name>Aircraft</object-name>
         <object-name>Pitch</object-name>
         <object-name>Roll</object-name>
         <object-name>RollReference</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>
             <blue> 0.5</blue>
             <factor-prop>/sim/model/material/instruments/integral-factor</factor-prop>
         </emission>
-    </animation-->
+    </animation>
 
     <animation>
         <type>material</type>

--- a/Models/Interior/Panel/Instruments/BatteryGauge/BatteryGauge.xml
+++ b/Models/Interior/Panel/Instruments/BatteryGauge/BatteryGauge.xml
@@ -16,17 +16,22 @@
         <object-name>Case</object-name>
     </effect>
 
-    <!--animation>
+    <animation>
         <type>material</type>
         <object-name>Face</object-name>
         <object-name>PtrTip</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>
             <blue> 0.5</blue>
             <factor-prop>/sim/model/material/instruments/integral-factor</factor-prop>
         </emission>
-    </animation-->
+    </animation>
 
     <animation>
         <type>rotate</type>

--- a/Models/Interior/Panel/Instruments/BatteryGauge/BatteryGauge.xml
+++ b/Models/Interior/Panel/Instruments/BatteryGauge/BatteryGauge.xml
@@ -20,6 +20,7 @@
         <type>material</type>
         <object-name>Face</object-name>
         <object-name>PtrTip</object-name>
+        <object-name>Case</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>

--- a/Models/Interior/Panel/Instruments/EGT/EGT.xml
+++ b/Models/Interior/Panel/Instruments/EGT/EGT.xml
@@ -45,6 +45,7 @@
         <object-name>Needle</object-name>
         <object-name>Bug</object-name>
         <object-name>Face</object-name>
+        <object-name>Case</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>

--- a/Models/Interior/Panel/Instruments/EGT/EGT.xml
+++ b/Models/Interior/Panel/Instruments/EGT/EGT.xml
@@ -40,18 +40,23 @@
         <bug>engines/engine[0]/egt-bug-norm</bug>
     </params>
 
-    <!--animation>
+    <animation>
         <type>material</type>
         <object-name>Needle</object-name>
         <object-name>Bug</object-name>
         <object-name>Face</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>
             <blue> 0.5</blue>
             <factor-prop>/sim/model/material/instruments/integral-factor</factor-prop>
         </emission>
-    </animation-->
+    </animation>
 
     <animation>
         <type>rotate</type>

--- a/Models/Interior/Panel/Instruments/FuelOilAmps/c172fuel.xml
+++ b/Models/Interior/Panel/Instruments/FuelOilAmps/c172fuel.xml
@@ -21,6 +21,7 @@
         <object-name>Face</object-name>
         <object-name>LeftFuelNeedle</object-name>
         <object-name>RightFuelNeedle</object-name>
+        <object-name>Case</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>

--- a/Models/Interior/Panel/Instruments/FuelOilAmps/c172fuel.xml
+++ b/Models/Interior/Panel/Instruments/FuelOilAmps/c172fuel.xml
@@ -16,18 +16,23 @@
         <object-name>Case</object-name>
     </effect>
 
-    <!--animation>
+    <animation>
         <type>material</type>
         <object-name>Face</object-name>
         <object-name>LeftFuelNeedle</object-name>
         <object-name>RightFuelNeedle</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>
             <blue> 0.5</blue>
             <factor-prop>/sim/model/material/instruments/integral-factor</factor-prop>
         </emission>
-    </animation-->
+    </animation>
 
     <animation>
         <type>rotate</type>

--- a/Models/Interior/Panel/Instruments/FuelOilAmps/c172oil.xml
+++ b/Models/Interior/Panel/Instruments/FuelOilAmps/c172oil.xml
@@ -21,6 +21,7 @@
         <object-name>Face</object-name>
         <object-name>OilTempNeedle</object-name>
         <object-name>OilPressNeedle</object-name>
+        <object-name>Case</object-name>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>

--- a/Models/Interior/Panel/Instruments/RPM/RPM.xml
+++ b/Models/Interior/Panel/Instruments/RPM/RPM.xml
@@ -26,6 +26,7 @@
         <type>material</type>
         <object-name>Face</object-name>
         <object-name>PointerTip</object-name>
+        <object-name>Case</object-name>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>

--- a/Models/Interior/Panel/Instruments/VSI/VSI.xml
+++ b/Models/Interior/Panel/Instruments/VSI/VSI.xml
@@ -21,6 +21,7 @@
         <object-name>Face</object-name>
         <object-name>PointerTip</object-name>
         <object-name>PointerCentre</object-name>
+        <object-name>Case</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>

--- a/Models/Interior/Panel/Instruments/VSI/VSI.xml
+++ b/Models/Interior/Panel/Instruments/VSI/VSI.xml
@@ -19,6 +19,8 @@
     <animation>
         <type>material</type>
         <object-name>Face</object-name>
+        <object-name>PointerTip</object-name>
+        <object-name>PointerCentre</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>

--- a/Models/Interior/Panel/Instruments/VSI/VSI.xml
+++ b/Models/Interior/Panel/Instruments/VSI/VSI.xml
@@ -16,16 +16,21 @@
         <object-name>Case</object-name>
     </effect>
 
-    <!--animation>
+    <animation>
         <type>material</type>
         <object-name>Face</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>
             <blue> 0.5</blue>
             <factor-prop>/sim/model/material/instruments/integral-factor</factor-prop>
         </emission>
-    </animation-->
+    </animation>
 
     <animation>
         <type>rotate</type>

--- a/Models/Interior/Panel/Instruments/alt/alt.xml
+++ b/Models/Interior/Panel/Instruments/alt/alt.xml
@@ -26,6 +26,7 @@
         <object-name>Needle10000</object-name>
         <object-name>Needle1000</object-name>
         <object-name>Needle100</object-name>
+        <object-name>Case</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>
@@ -39,9 +40,10 @@
         </emission>
     </animation>
 
-    <animation>
+    <!--animation>
         <type>material</type>
         <object-name>disk</object-name>
+        <object-name>Case</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>
@@ -53,7 +55,7 @@
             <blue>0.00001</blue>
             <factor-prop>/sim/model//material/instruments/factor</factor-prop>
         </emission>
-    </animation>
+    </animation-->
 
     <animation>
         <type>rotate</type>

--- a/Models/Interior/Panel/Instruments/alt/alt.xml
+++ b/Models/Interior/Panel/Instruments/alt/alt.xml
@@ -19,31 +19,41 @@
         <object-name>Case</object-name>
     </effect>
 
-    <!--animation>
+    <animation>
         <type>material</type>
         <object-name>Face</object-name>
         <object-name>inhg</object-name>
         <object-name>Needle10000</object-name>
         <object-name>Needle1000</object-name>
         <object-name>Needle100</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>
             <blue> 0.5</blue>
             <factor-prop>/sim/model/material/instruments/integral-factor</factor-prop>
         </emission>
-    </animation-->
+    </animation>
 
-    <!--animation>
+    <animation>
         <type>material</type>
         <object-name>disk</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>0.45</red>
             <green>0.09</green>
             <blue>0.00001</blue>
             <factor-prop>/sim/model//material/instruments/factor</factor-prop>
         </emission>
-    </animation-->
+    </animation>
 
     <animation>
         <type>rotate</type>

--- a/Models/Interior/Panel/Instruments/asi/asi.xml
+++ b/Models/Interior/Panel/Instruments/asi/asi.xml
@@ -20,6 +20,7 @@
         <type>material</type>
         <object-name>Face</object-name>
         <object-name>Needle</object-name>
+        <object-name>Case</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>

--- a/Models/Interior/Panel/Instruments/asi/asi.xml
+++ b/Models/Interior/Panel/Instruments/asi/asi.xml
@@ -16,17 +16,22 @@
         <object-name>Case</object-name>
     </effect>
 
-    <!--animation>
+    <animation>
         <type>material</type>
         <object-name>Face</object-name>
         <object-name>Needle</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>
             <blue> 0.5</blue>
             <factor-prop>/sim/model/material/instruments/integral-factor</factor-prop>
         </emission>
-    </animation-->
+    </animation>
 
     <animation>
         <type>rotate</type>

--- a/Models/Interior/Panel/Instruments/clock/clock.xml
+++ b/Models/Interior/Panel/Instruments/clock/clock.xml
@@ -23,6 +23,7 @@
         <object-name>SecondHand</object-name>
         <object-name>MinuteHand</object-name>
         <object-name>HourHand</object-name>
+        <object-name>Case</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>

--- a/Models/Interior/Panel/Instruments/clock/clock.xml
+++ b/Models/Interior/Panel/Instruments/clock/clock.xml
@@ -17,19 +17,24 @@
         <object-name>Case</object-name>
     </effect>
 
-    <!--animation>
+    <animation>
         <type>material</type>
         <object-name>Face</object-name>
         <object-name>SecondHand</object-name>
         <object-name>MinuteHand</object-name>
         <object-name>HourHand</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>
             <blue> 0.5</blue>
             <factor-prop>/sim/model/material/instruments/integral-factor</factor-prop>
         </emission>
-    </animation-->
+    </animation>
 
     <animation>
         <type>rotate</type>

--- a/Models/Interior/Panel/Instruments/digital-clock/digital-clock.xml
+++ b/Models/Interior/Panel/Instruments/digital-clock/digital-clock.xml
@@ -16,20 +16,6 @@
         <inherits-from>../../../../Effects/interior/interior-glass-reflection-panel-front</inherits-from>
         <object-name>glass_panel</object-name>
     </effect>
-    
-    <animation>
-        <type>material</type>
-        <object-name>HR.001</object-name>
-        <object-name>HR.002</object-name>
-        <object-name>MN.001</object-name>
-        <object-name>MN.002</object-name>
-        <emission>
-            <red>1.0</red>
-            <green>0.95</green>
-            <blue>0.88</blue>
-            <factor-prop>controls/lighting/radio-norm</factor-prop>
-        </emission>
-    </animation>
 
     <animation>
         <type>material</type>
@@ -38,6 +24,7 @@
         <object-name>HR.002</object-name>
         <object-name>MN.001</object-name>
         <object-name>MN.002</object-name>
+        <object-name>Case</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>

--- a/Models/Interior/Panel/Instruments/digital-clock/digital-clock.xml
+++ b/Models/Interior/Panel/Instruments/digital-clock/digital-clock.xml
@@ -19,7 +19,6 @@
     
     <animation>
         <type>material</type>
-        <object-name>DigitalClock</object-name>
         <object-name>HR.001</object-name>
         <object-name>HR.002</object-name>
         <object-name>MN.001</object-name>
@@ -29,6 +28,26 @@
             <green>0.95</green>
             <blue>0.88</blue>
             <factor-prop>controls/lighting/radio-norm</factor-prop>
+        </emission>
+    </animation>
+
+    <animation>
+        <type>material</type>
+        <object-name>DigitalClock</object-name>
+        <object-name>HR.001</object-name>
+        <object-name>HR.002</object-name>
+        <object-name>MN.001</object-name>
+        <object-name>MN.002</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
+        <emission>
+            <red>1.0</red>
+            <green>0.95</green>
+            <blue>0.88</blue>
+            <factor-prop>/sim/model/material/instruments/integral-factor</factor-prop>
         </emission>
     </animation>
     

--- a/Models/Interior/Panel/Instruments/hi/hi.xml
+++ b/Models/Interior/Panel/Instruments/hi/hi.xml
@@ -18,18 +18,23 @@
         <object-name>Case</object-name>
     </effect>
 
-    <!--animation>
+    <animation>
         <type>material</type>
         <object-name>Face</object-name>
         <object-name>Front</object-name>
         <object-name>HdgBug</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>
             <blue> 0.5</blue>
             <factor-prop>/sim/model/material/instruments/integral-factor</factor-prop>
         </emission>
-    </animation-->
+    </animation>
 
     <animation>
         <type>rotate</type>

--- a/Models/Interior/Panel/Instruments/hi/hi.xml
+++ b/Models/Interior/Panel/Instruments/hi/hi.xml
@@ -23,6 +23,7 @@
         <object-name>Face</object-name>
         <object-name>Front</object-name>
         <object-name>HdgBug</object-name>
+        <object-name>Case</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>

--- a/Models/Interior/Panel/Instruments/hobbs/hobbs.xml
+++ b/Models/Interior/Panel/Instruments/hobbs/hobbs.xml
@@ -29,13 +29,18 @@
         <object-name>Drum.4</object-name>
     </animation>
 
-    <!--animation>
+    <animation>
         <type>material</type>
         <object-name>Drum.0</object-name>
         <object-name>Drum.1</object-name>
         <object-name>Drum.2</object-name>
         <object-name>Drum.3</object-name>
         <object-name>Drum.4</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <condition>
             <property>/controls/lighting/instrument-lights</property>
         </condition>
@@ -44,7 +49,7 @@
             <green> 0.50 </green>
             <blue>  0.50 </blue>
         </emission>
-    </animation-->
+    </animation>
 
     <animation>
         <type>textranslate</type>

--- a/Models/Interior/Panel/Instruments/hobbs/hobbs.xml
+++ b/Models/Interior/Panel/Instruments/hobbs/hobbs.xml
@@ -31,6 +31,7 @@
 
     <animation>
         <type>material</type>
+        <object-name>Base</object-name>
         <object-name>Drum.0</object-name>
         <object-name>Drum.1</object-name>
         <object-name>Drum.2</object-name>
@@ -41,13 +42,11 @@
                 <property>/sim/rendering/shaders/skydome</property>
             </not>
         </condition>
-        <condition>
-            <property>/controls/lighting/instrument-lights</property>
-        </condition>
         <emission>
-            <red>   0.80 </red>
-            <green> 0.50 </green>
-            <blue>  0.50 </blue>
+            <red>  1.0</red>
+            <green>0.8</green>
+            <blue> 0.5</blue>
+            <factor-prop>/sim/model/material/instruments/integral-factor</factor-prop>
         </emission>
     </animation>
 

--- a/Models/Interior/Panel/Instruments/kr87-adf/ki227_228.xml
+++ b/Models/Interior/Panel/Instruments/kr87-adf/ki227_228.xml
@@ -27,9 +27,9 @@
     <effect>
         <inherits-from>../../../../Effects/interior/lm-adf</inherits-from>
         <object-name>CompassRoseCenter</object-name>
-        <object-name>Chassis</object-name>
         <object-name>Marker</object-name>
         <object-name>Case</object-name>
+        <object-name>AircraftSymbol</object-name>
     </effect>
 
     <animation>
@@ -39,9 +39,11 @@
     <animation>
         <type>material</type>
         <object-name>CompassRose</object-name>
+        <object-name>CompassRoseCenter</object-name>
         <object-name>KI227.ADFNeedle</object-name>
         <object-name>Marker</object-name>
         <object-name>Case</object-name>
+        <object-name>AircraftSymbol</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>

--- a/Models/Interior/Panel/Instruments/kr87-adf/ki227_228.xml
+++ b/Models/Interior/Panel/Instruments/kr87-adf/ki227_228.xml
@@ -41,6 +41,7 @@
         <object-name>CompassRose</object-name>
         <object-name>KI227.ADFNeedle</object-name>
         <object-name>Marker</object-name>
+        <object-name>Case</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>

--- a/Models/Interior/Panel/Instruments/kr87-adf/ki227_228.xml
+++ b/Models/Interior/Panel/Instruments/kr87-adf/ki227_228.xml
@@ -36,18 +36,23 @@
         <type>noshadow</type>
     </animation>
 
-    <!--animation>
+    <animation>
         <type>material</type>
         <object-name>CompassRose</object-name>
         <object-name>KI227.ADFNeedle</object-name>
         <object-name>Marker</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>
             <blue> 0.5</blue>
             <factor-prop>/sim/model/material/instruments/integral-factor</factor-prop>
         </emission>
-    </animation-->
+    </animation>
 
 
     <animation>

--- a/Models/Interior/Panel/Instruments/mag-compass/mag-compass-float.xml
+++ b/Models/Interior/Panel/Instruments/mag-compass/mag-compass-float.xml
@@ -53,6 +53,11 @@
         <type>material</type>
         <object-name>Ring</object-name>
         <object-name>Needle</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>

--- a/Models/Interior/Panel/Instruments/mag-compass/mag-compass.xml
+++ b/Models/Interior/Panel/Instruments/mag-compass/mag-compass.xml
@@ -53,6 +53,11 @@
         <type>material</type>
         <object-name>Ring</object-name>
         <object-name>Needle</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>

--- a/Models/Interior/Panel/Instruments/tc/tc.xml
+++ b/Models/Interior/Panel/Instruments/tc/tc.xml
@@ -24,6 +24,7 @@
         <object-name>Face</object-name>
         <object-name>Airplane</object-name>
         <object-name>Background</object-name>
+        <object-name>Case</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>

--- a/Models/Interior/Panel/Instruments/tc/tc.xml
+++ b/Models/Interior/Panel/Instruments/tc/tc.xml
@@ -18,19 +18,24 @@
         <object-name>Case</object-name>
     </effect>
 
-    <!--animation>
+    <animation>
         <type>material</type>
         <object-name>Ball</object-name>
         <object-name>Face</object-name>
         <object-name>Airplane</object-name>
         <object-name>Background</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>
             <blue> 0.5</blue>
             <factor-prop>/sim/model/material/instruments/integral-factor</factor-prop>
         </emission>
-    </animation-->
+    </animation>
 
     <animation>
         <type>rotate</type>

--- a/Models/Interior/Panel/Instruments/vac/vac.xml
+++ b/Models/Interior/Panel/Instruments/vac/vac.xml
@@ -19,6 +19,7 @@
         <type>material</type>
         <object-name>VacFace</object-name>
         <object-name>VacNeedle</object-name>
+        <object-name>Case</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>

--- a/Models/Interior/Panel/Instruments/vac/vac.xml
+++ b/Models/Interior/Panel/Instruments/vac/vac.xml
@@ -15,17 +15,22 @@
         <object-name>Case</object-name>
     </effect>
 
-    <!--animation>
+    <animation>
         <type>material</type>
         <object-name>VacFace</object-name>
         <object-name>VacNeedle</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>
             <blue> 0.5</blue>
             <factor-prop>/sim/model/material/instruments/integral-factor</factor-prop>
         </emission>
-    </animation-->
+    </animation>
 
     <animation>
         <type>rotate</type>

--- a/Models/Interior/Panel/Instruments/vor/vor.xml
+++ b/Models/Interior/Panel/Instruments/vor/vor.xml
@@ -33,7 +33,7 @@
         <object-name>Case</object-name>
     </effect>
 
-    <!--animation>
+    <animation>
         <type>material</type>
         <object-name>Face</object-name>
         <object-name>GlideslopeNeedle</object-name>
@@ -44,13 +44,18 @@
         <object-name>NAV</object-name>
         <object-name>GS_out_of_range</object-name>
         <object-name>GS_in_range</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>
             <blue> 0.5</blue>
             <factor-prop>/sim/model/material/instruments/integral-factor</factor-prop>
         </emission>
-    </animation-->
+    </animation>
 
     <animation>
         <type>material</type>

--- a/Models/Interior/Panel/Instruments/vor/vor.xml
+++ b/Models/Interior/Panel/Instruments/vor/vor.xml
@@ -44,6 +44,7 @@
         <object-name>NAV</object-name>
         <object-name>GS_out_of_range</object-name>
         <object-name>GS_in_range</object-name>
+        <object-name>Case</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>

--- a/Models/Interior/Panel/Instruments/vor/vor2.xml
+++ b/Models/Interior/Panel/Instruments/vor/vor2.xml
@@ -33,7 +33,7 @@
         <object-name>Case</object-name>
     </effect>
 
-    <!--animation>
+    <animation>
         <type>material</type>
         <object-name>Face</object-name>
         <object-name>GlideslopeNeedle</object-name>
@@ -44,13 +44,18 @@
         <object-name>NAV</object-name>
         <object-name>GS_out_of_range</object-name>
         <object-name>GS_in_range</object-name>
+        <condition>
+            <not>
+                <property>/sim/rendering/shaders/skydome</property>
+            </not>
+        </condition>
         <emission>
             <red>  1.0</red>
             <green>0.8</green>
             <blue> 0.5</blue>
             <factor-prop>/sim/model/material/instruments/integral-factor</factor-prop>
         </emission>
-    </animation-->
+    </animation>
 
     <animation>
         <type>material</type>

--- a/Models/Interior/Panel/Instruments/vor/vor2.xml
+++ b/Models/Interior/Panel/Instruments/vor/vor2.xml
@@ -44,6 +44,7 @@
         <object-name>NAV</object-name>
         <object-name>GS_out_of_range</object-name>
         <object-name>GS_in_range</object-name>
+        <object-name>Case</object-name>
         <condition>
             <not>
                 <property>/sim/rendering/shaders/skydome</property>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -858,6 +858,9 @@
         <object-name>doorhandleint_right</object-name>
         <object-name>doorhandleint_left</object-name>
         <object-name>CeilingSpeaker</object-name>
+        <object-name>DomeSliderWhite</object-name>
+        <object-name>DomeSwitchWhite</object-name>
+        <object-name>DomeSwitchRed</object-name>
         <object-name>light-knob-base</object-name>
         <object-name>AltStaticAir</object-name>
         <object-name>LowVoltageLed</object-name>
@@ -870,7 +873,6 @@
         <object-name>InstrumentCover</object-name>
         <object-name>panel_1_1.inf</object-name>
         <object-name>panel_1_1_right</object-name>
-        <object-name>Panel_0</object-name>
         <object-name>gloveboxdoor</object-name>
         <object-name>glovebox</object-name>
         <object-name>gloveboxfull</object-name>

--- a/Systems/als-lights.xml
+++ b/Systems/als-lights.xml
@@ -341,7 +341,7 @@
         </output>
     </logic>
 
-    <filter>
+    <!--filter>
         <name>Inst Red Factor</name>
         <type>gain</type>
         <gain>0.010</gain>
@@ -453,7 +453,7 @@
         <output>
             <property>/sim/model/c172p/lighting/inst-b-norm</property>
         </output>
-    </filter>
+    </filter-->
 
     <!-- Reduce the red glow from the digits of the radio stack
          if the instrument lighting is at 100 %.
@@ -473,9 +473,9 @@
         <output>
             <property>/sim/model/c172p/lighting/inst-gain</property>
         </output>
-    </filter-->
+    </filter>
 
-    <!--filter>
+    <filter>
         <name>RGB Red Factor</name>
         <type>gain</type>
         <input>

--- a/Systems/als-lights.xml
+++ b/Systems/als-lights.xml
@@ -458,7 +458,7 @@
     <!-- Reduce the red glow from the digits of the radio stack
          if the instrument lighting is at 100 %.
     -->
-    <filter>
+    <!--filter>
         <name>Inst Gain As Function Of Instrument Lighting</name>
         <type>gain</type>
         <input>
@@ -473,9 +473,9 @@
         <output>
             <property>/sim/model/c172p/lighting/inst-gain</property>
         </output>
-    </filter>
+    </filter-->
 
-    <filter>
+    <!--filter>
         <name>RGB Red Factor</name>
         <type>gain</type>
         <input>
@@ -533,7 +533,7 @@
         <output>
             <property>/sim/model/c172p/lighting/rgb-ra-b-factor</property>
         </output>
-    </filter>
+    </filter-->
 
     <filter>
         <type>gain</type>


### PR DESCRIPTION
Fixes #1192 

@onox 
This is the bare minimum so far. Shader set to lowest setting does not work, you have to have ALS off.
Do we also want this as a fallback for the shader setting?

I can try to integrate some ambient radiant light later on this evening too if we wan't. Without it it looks a bit dark as you can't see anything but the gauges.