### PR TITLE
setting initial frequencies

### DIFF
--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -727,14 +727,14 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <volume type="double">0.7</volume>
             <frequencies>
                 <dial-1-khz type="int">0</dial-1-khz>
-                <dial-100-khz type="int">0</dial-100-khz>
+                <dial-100-khz type="int">2</dial-100-khz>
             </frequencies>
         </adf>
         <comm n="0">
             <power-btn type="bool">1</power-btn>
             <frequencies>
                 <dial-khz type="int">0</dial-khz>
-                <dial-mhz type="int">0</dial-mhz>
+                <dial-mhz type="int">118</dial-mhz>
             </frequencies>
             <volume-selected type="double">0.7</volume-selected>
         </comm>
@@ -742,7 +742,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <power-btn type="bool">1</power-btn>
             <frequencies>
                 <dial-khz type="int">0</dial-khz>
-                <dial-mhz type="int">0</dial-mhz>
+                <dial-mhz type="int">118</dial-mhz>
             </frequencies>
             <volume-selected type="double">0.7</volume-selected>
         </comm>
@@ -750,7 +750,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <volume type="double">0.7</volume>
             <frequencies>
                 <dial-khz type="int">0</dial-khz>
-                <dial-mhz type="int">0</dial-mhz>
+                <dial-mhz type="int">108</dial-mhz>
             </frequencies>
             <ident-audible type="bool">false</ident-audible>
         </nav>
@@ -758,7 +758,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <volume type="double">0.7</volume>
             <frequencies>
                 <dial-khz type="int">0</dial-khz>
-                <dial-mhz type="int">0</dial-mhz>
+                <dial-mhz type="int">108</dial-mhz>
             </frequencies>
             <ident-audible type="bool">false</ident-audible>
         </nav>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -727,14 +727,18 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <volume type="double">0.7</volume>
             <frequencies>
                 <dial-1-khz type="int">0</dial-1-khz>
-                <dial-100-khz type="int">2</dial-100-khz>
+                <dial-100-khz type="int">0</dial-100-khz>
+                <standby-mhz type="double">200.0</standby-mhz>
+                <selected-mhz type="double">200.0</selected-mhz>
             </frequencies>
         </adf>
         <comm n="0">
             <power-btn type="bool">1</power-btn>
             <frequencies>
                 <dial-khz type="int">0</dial-khz>
-                <dial-mhz type="int">118</dial-mhz>
+                <dial-mhz type="int">0</dial-mhz>
+                <standby-mhz type="double">118.0</standby-mhz>
+                <selected-mhz type="double">118.0</selected-mhz>
             </frequencies>
             <volume-selected type="double">0.7</volume-selected>
         </comm>
@@ -742,7 +746,9 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <power-btn type="bool">1</power-btn>
             <frequencies>
                 <dial-khz type="int">0</dial-khz>
-                <dial-mhz type="int">118</dial-mhz>
+                <dial-mhz type="int">0</dial-mhz>
+                <standby-mhz type="double">118.0</standby-mhz>
+                <selected-mhz type="double">118.0</selected-mhz>
             </frequencies>
             <volume-selected type="double">0.7</volume-selected>
         </comm>
@@ -750,7 +756,9 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <volume type="double">0.7</volume>
             <frequencies>
                 <dial-khz type="int">0</dial-khz>
-                <dial-mhz type="int">108</dial-mhz>
+                <dial-mhz type="int">0</dial-mhz>
+                <standby-mhz type="double">108.0</standby-mhz>
+                <selected-mhz type="double">108.0</selected-mhz>
             </frequencies>
             <ident-audible type="bool">false</ident-audible>
         </nav>
@@ -758,7 +766,9 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <volume type="double">0.7</volume>
             <frequencies>
                 <dial-khz type="int">0</dial-khz>
-                <dial-mhz type="int">108</dial-mhz>
+                <dial-mhz type="int">0</dial-mhz>
+                <standby-mhz type="double">108.0</standby-mhz>
+                <selected-mhz type="double">108.0</selected-mhz>
             </frequencies>
             <ident-audible type="bool">false</ident-audible>
         </nav>


### PR DESCRIPTION
Currently, the frequencies are set to `0` in the `-set.xml` file. I've changed them to the minimum value each can have:

`118.0` for COMMs
`108.0` for NAVs
`200` for ADF