### PR TITLE
Initial frequencies

### DIFF
--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -728,8 +728,8 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <frequencies>
                 <dial-1-khz type="int">0</dial-1-khz>
                 <dial-100-khz type="int">0</dial-100-khz>
-                <standby-mhz type="double">200.0</standby-mhz>
-                <selected-mhz type="double">200.0</selected-mhz>
+                <standby-khz type="double">200.0</standby-khz>
+                <selected-khz type="double">200.0</selected-khz>
             </frequencies>
         </adf>
         <comm n="0">


### PR DESCRIPTION
@wlbragg What @wkitty42 wrote was right, those frequencies are saved in the autosave files in `~/.fgfs`, so to test this one needs to delete those and also the `c172p.xml` file from `aircraft-data`. After doing that the COMM and NAV frequencies were resetting correctly to 108.00 and 118.00 Mhz, but the ADF uses Khz and not Mhz. This commit fixes that and resets it to 200.0 as expected. Please test and merge this so that I can cherry pick it.