### PR TITLE
Limit visor rotations

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -3202,8 +3202,8 @@
                 <command>property-adjust</command>
                 <property>controls/visorleft/position-deg</property>
                 <factor>5</factor>
-                <min>0</min>
-                <max>140</max>
+                <min>10</min>
+                <max>90</max>
                 <wrap>false</wrap>
             </binding>
         </action>
@@ -3230,8 +3230,8 @@
                 <command>property-adjust</command>
                 <property>controls/visorright/position-deg</property>
                 <factor>5</factor>
-                <min>0</min>
-                <max>140</max>
+                <min>10</min>
+                <max>90</max>
                 <wrap>false</wrap>
             </binding>
         </action>
@@ -3239,7 +3239,7 @@
     <animation>
         <type>knob</type>
         <object-name>visorrodleft</object-name>
-        <!--object-name>visorbaseleft</object-name-->
+        <object-name>visorleft</object-name>
         <property>controls/visorrodleft/position-deg</property>
         <factor>1</factor>
         <drag-direction>horizontal</drag-direction>
@@ -3260,32 +3260,15 @@
                 <property>controls/visorrodleft/position-deg</property>
                 <factor>5</factor>
                 <min>-30</min>
-                <max>15</max>
+                <max>12</max>
                 <wrap>false</wrap>
             </binding>
         </action>
     </animation>
     <animation>
-        <type>rotate</type>
-        <object-name>visorleft</object-name>
-        <property>controls/visorrodleft/position-deg</property>
-        <factor>1</factor>
-        <offset-deg>0</offset-deg>
-        <center>
-            <x-m> 0.10647</x-m>
-            <y-m>-0.40846</y-m>
-            <z-m> 0.47832</z-m>
-        </center>
-        <axis>
-            <x>.3</x>
-            <y>.03</y>
-            <z>1</z>
-        </axis>
-    </animation>
-    <animation>
         <type>knob</type>
         <object-name>visorrodright</object-name>
-        <!--object-name>visorbaseright</object-name-->
+        <object-name>visorright</object-name>
         <property>controls/visorrodright/position-deg</property>
         <factor>1</factor>
         <drag-direction>horizontal</drag-direction>
@@ -3306,27 +3289,10 @@
                 <property>controls/visorrodright/position-deg</property>
                 <factor>5</factor>
                 <min>-30</min>
-                <max>15</max>
+                <max>12</max>
                 <wrap>false</wrap>
             </binding>
         </action>
-    </animation>
-    <animation>
-        <type>rotate</type>
-        <object-name>visorright</object-name>
-        <property>controls/visorrodright/position-deg</property>
-        <factor>1</factor>
-        <offset-deg>0</offset-deg>
-        <center>
-            <x-m>0.1063 </x-m>
-            <y-m>0.40887</y-m>
-            <z-m>0.48035</z-m>
-        </center>
-        <axis>
-            <x>-.3</x>
-            <y>-.03</y>
-            <z>-1</z>
-        </axis>
     </animation>
 
     <!-- MOD: animation for the checklists -->

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -3183,7 +3183,7 @@
     <animation>
         <type>knob</type>
         <object-name>visorleft</object-name>
-        <property>controls/visorleft/position-deg</property>
+        <property>controls/visors/left/visor-position-deg</property>
         <factor>1</factor>
         <drag-direction>vertical</drag-direction>
         <offset-deg>0</offset-deg>
@@ -3200,7 +3200,7 @@
         <action>
             <binding>
                 <command>property-adjust</command>
-                <property>controls/visorleft/position-deg</property>
+                <property>controls/visors/left/visor-position-deg</property>
                 <factor>5</factor>
                 <min>10</min>
                 <max>90</max>
@@ -3211,7 +3211,7 @@
     <animation>
         <type>knob</type>
         <object-name>visorright</object-name>
-        <property>controls/visorright/position-deg</property>
+        <property>controls/visors/right/visor-position-deg</property>
         <factor>1</factor>
         <drag-direction>vertical</drag-direction>
         <offset-deg>0</offset-deg>
@@ -3228,7 +3228,7 @@
         <action>
             <binding>
                 <command>property-adjust</command>
-                <property>controls/visorright/position-deg</property>
+                <property>controls/visors/right/visor-position-deg</property>
                 <factor>5</factor>
                 <min>10</min>
                 <max>90</max>
@@ -3240,7 +3240,7 @@
         <type>knob</type>
         <object-name>visorrodleft</object-name>
         <object-name>visorleft</object-name>
-        <property>controls/visorrodleft/position-deg</property>
+        <property>controls/visors/left/rod-position-deg</property>
         <factor>1</factor>
         <drag-direction>horizontal</drag-direction>
         <offset-deg>0</offset-deg>
@@ -3257,7 +3257,7 @@
         <action>
             <binding>
                 <command>property-adjust</command>
-                <property>controls/visorrodleft/position-deg</property>
+                <property>controls/visors/left/rod-position-deg</property>
                 <factor>5</factor>
                 <min>-30</min>
                 <max>12</max>
@@ -3269,7 +3269,7 @@
         <type>knob</type>
         <object-name>visorrodright</object-name>
         <object-name>visorright</object-name>
-        <property>controls/visorrodright/position-deg</property>
+        <property>controls/visors/right/rod-position-deg</property>
         <factor>1</factor>
         <drag-direction>horizontal</drag-direction>
         <offset-deg>0</offset-deg>
@@ -3286,7 +3286,7 @@
         <action>
             <binding>
                 <command>property-adjust</command>
-                <property>controls/visorrodright/position-deg</property>
+                <property>controls/visors/right/rod-position-deg</property>
                 <factor>5</factor>
                 <min>-30</min>
                 <max>12</max>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -655,6 +655,16 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <go-to-mooring type="bool">false</go-to-mooring>
             <port-available type="bool">false</port-available>
         </mooring>
+        <visors>
+            <left>
+                <rod-position-deg type="int">0</rod-position-deg>
+                <visor-position-deg type="int">0</visor-position-deg>
+            </left>
+            <right>
+                <rod-position-deg type="int">0</rod-position-deg>
+                <visor-position-deg type="int">0</visor-position-deg>
+            </right>
+        </visors>
     </controls>
 
     <autopilot>


### PR DESCRIPTION
Fixes #1210 

Visor rotations are allowing the visors to rotate out of bounds and through solid objects. This PR corrects that issue.

I have some confusion as to why this is happening and also the numbers don't seem accurate to me.

The rotation visually looks like it should be close to 180, it was at 140 but now needs to be at 90.