### PR TITLE
Add altitude-agl-m signal to flight recorder

### DIFF
--- a/Systems/flight-recorder/components/effects.xml
+++ b/Systems/flight-recorder/components/effects.xml
@@ -85,4 +85,10 @@
         <property type="string">/fdm/jsbsim/hydro/spray-wake-speed-kt-actual</property>
     </signal>
 
+    <!-- 3d Shadow -->
+    <signal>
+        <type>float</type>
+        <property type="string">/position/altitude-agl-m</property>
+    </signal>
+
 </PropertyList>


### PR DESCRIPTION
Fixes #1212 

I'm doing this in the blind as I am unable to record tapes right now for some reason. It crashes my fg session when I hit save. I have tried a few different directories to no avail

If someone can test this and see if this ail all that is needed I would appreciate it.