### PR TITLE
Mixture set to 1 at sea level in autostart

### DIFF
--- a/Systems/c172p-engine.xml
+++ b/Systems/c172p-engine.xml
@@ -206,7 +206,7 @@
         </switch>
 
         <fcs_function name="auto-engine-mixture">
-            <function> <!-- Mixture -- RICH (above 3000 feet, LEAN to obtain maximum RPM) -->
+            <function> <!-- Mixture rich above 3000 feet, LEAN to obtain maximum RPM -->
                 <sum>
                     <value>0</value>
                     <table>

--- a/Systems/c172p-engine.xml
+++ b/Systems/c172p-engine.xml
@@ -206,13 +206,13 @@
         </switch>
 
         <fcs_function name="auto-engine-mixture">
-            <function> <!-- mixture to 1 at sea level in autostart, state autostarts and tutorials, default mixture setting is .95 -->
+            <function> <!-- Mixture -- RICH (above 3000 feet, LEAN to obtain maximum RPM) -->
                 <sum>
                     <value>0</value>
                     <table>
                         <independentVar>/position/altitude-ft</independentVar>
                         <tableData>
-                            0       1.00
+                            3000    1.00
                             13000   0.75
                         </tableData>
                     </table>

--- a/Systems/c172p-engine.xml
+++ b/Systems/c172p-engine.xml
@@ -206,13 +206,13 @@
         </switch>
 
         <fcs_function name="auto-engine-mixture">
-            <function>
-                <sum>
+            <function> <!-- mixture to 1 at sea level in autostart, state autostarts and tutorials, default mixture setting is .95 -->
+                <sum
                     <value>0</value>
                     <table>
                         <independentVar>/position/altitude-ft</independentVar>
                         <tableData>
-                            0       0.95
+                            0       1.00
                             13000   0.75
                         </tableData>
                     </table>

--- a/Systems/c172p-engine.xml
+++ b/Systems/c172p-engine.xml
@@ -207,7 +207,7 @@
 
         <fcs_function name="auto-engine-mixture">
             <function> <!-- mixture to 1 at sea level in autostart, state autostarts and tutorials, default mixture setting is .95 -->
-                <sum
+                <sum>
                     <value>0</value>
                     <table>
                         <independentVar>/position/altitude-ft</independentVar>


### PR DESCRIPTION
Fixes #791

Simple change to autostart mixture at sea level to 1 VS .95 for full power.

This should be ready to merge after review.