### PR TITLE
Define unuseable fuel

### DIFF
--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -688,6 +688,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
                 <water-contamination type="double">0.0</water-contamination>
                 <sample-water-contamination type="double">0.0</sample-water-contamination>
                 <fuel-sample-taken type="bool">false</fuel-sample-taken>
+				<unusable-gal_us type="double">1.5</unusable-gal_us>
             </tank>
             <tank n="1">
                 <name>Right tank</name>
@@ -696,6 +697,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
                 <water-contamination type="double">0.0</water-contamination>
                 <sample-water-contamination type="double">0.0</sample-water-contamination>
                 <fuel-sample-taken type="bool">false</fuel-sample-taken>
+				<unusable-gal_us type="double">1.5</unusable-gal_us>
             </tank>
             <tank n="2">
                 <name>Float chamber 1</name>


### PR DESCRIPTION
This defines unuseable fuel. I will write to the JSBSIM git repository asking this actually do something - it is better that FlightGear handle this if possible, without us doing any hacks to the fuel system.