### PR TITLE
fixes #1219 - missing less-than symbol on property tag causing "empty 'not' condition" error

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -7610,7 +7610,7 @@
                     <value>400</value>
                 </greater-than>
                 <not>
-                    property alias="/params/securing/cowl-plugs"/>
+                    <property alias="/params/securing/cowl-plugs"/>
                 </not>
                 <not>
                     <property alias="/params/engine/crashed"/>


### PR DESCRIPTION
this was a fun one to find... especially after i figured out the xpath stuff for searching xml files :smile_cat: 