### PR TITLE
Increase wind speed required to drive rain animation over windshield

### DIFF
--- a/Systems/glass-rain.xml
+++ b/Systems/glass-rain.xml
@@ -112,7 +112,7 @@
             <condition>
                 <greater-than-equals>
                     <property>/velocities/airspeed-kt</property>
-                    <value>5</value>
+                    <value>20</value>
                 </greater-than-equals>
             </condition>
             <property>/environment/aircraft-effects/splash-xa</property>
@@ -121,7 +121,7 @@
             <condition>
                 <less-than>
                     <property>/velocities/airspeed-kt</property>
-                    <value>5</value>
+                    <value>20</value>
                 </less-than>
             </condition>
             <property>/environment/aircraft-effects/splash-xr</property>
@@ -153,7 +153,7 @@
             <condition>
                 <greater-than-equals>
                     <property>/velocities/airspeed-kt</property>
-                    <value>5</value>
+                    <value>20</value>
                 </greater-than-equals>
             </condition>
             <property>/environment/aircraft-effects/splash-za</property>
@@ -162,7 +162,7 @@
             <condition>
                 <less-than>
                     <property>/velocities/airspeed-kt</property>
-                    <value>5</value>
+                    <value>20</value>
                 </less-than>
             </condition>
             <property>/environment/aircraft-effects/splash-zr</property>


### PR DESCRIPTION
Fixes #1251 

This is ready to merge unless we want to increase the windspeed value even higher.