### PR TITLE
FDM adjustment based on it0uchpods' feedback

### DIFF
--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -584,8 +584,8 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 
     <controls>
         <flight>
-            <aileron-trim type="double">0.022</aileron-trim>
-            <rudder-trim type="double">0.02</rudder-trim>
+            <aileron-trim type="double">0.0</aileron-trim> <!-- c172 has no such thing -->
+            <rudder-trim type="double">0.01</rudder-trim>
             <rudder-trim-knob type="double">0.0</rudder-trim-knob>
             <freeze-yoke type="bool">false</freeze-yoke>
             <aileron-cmd type="double">0.0</aileron-cmd>
@@ -1144,7 +1144,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             </settings>
             <aero>
                 <coefficient>
-                    <spiral-propwash-coeff type="double">0.180</spiral-propwash-coeff>
+                    <spiral-propwash-coeff type="double">0.120</spiral-propwash-coeff>
                 </coefficient>
             </aero>
             <fcs>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -1144,7 +1144,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             </settings>
             <aero>
                 <coefficient>
-                    <spiral-propwash-coeff type="double">0.25</spiral-propwash-coeff>
+                    <spiral-propwash-coeff type="double">0.180</spiral-propwash-coeff>
                 </coefficient>
             </aero>
             <fcs>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -1144,7 +1144,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             </settings>
             <aero>
                 <coefficient>
-                    <spiral-propwash-coeff type="double">0.120</spiral-propwash-coeff>
+                    <spiral-propwash-coeff type="double">0.175</spiral-propwash-coeff>
                 </coefficient>
             </aero>
             <fcs>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -1144,7 +1144,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             </settings>
             <aero>
                 <coefficient>
-                    <spiral-propwash-coeff type="double">0.175</spiral-propwash-coeff>
+                    <spiral-propwash-coeff type="double">0.185</spiral-propwash-coeff>
                 </coefficient>
             </aero>
             <fcs>

--- a/c172p.xml
+++ b/c172p.xml
@@ -588,7 +588,7 @@
                     <yaw> 0.0 </yaw>
                 </orient>
                 <sense> 1 </sense>
-                <p_factor> 59 </p_factor>
+                <p_factor> 5 </p_factor>
             </thruster>
         </engine>
 
@@ -617,7 +617,7 @@
                     <yaw> 0.0 </yaw>
                 </orient>
                 <sense> 1 </sense>
-                <p_factor> 60 </p_factor>
+                <p_factor> 6 </p_factor>
             </thruster>
         </engine>
 
@@ -1868,7 +1868,7 @@
                         <independentVar lookup="column">aero/beta-rad</independentVar>
                         <tableData>
                                     -0.35        0           0.35
-                            0       -0.0216      -0.0216     -0.0216
+                            0       -0.0166      -0.0166     -0.0166
                             0.070   -0.039       -0.0786     -0.039
                             0.094   -0.025       -0.0504     -0.025
                         </tableData>

--- a/c172p.xml
+++ b/c172p.xml
@@ -1626,7 +1626,7 @@
                     </table>
                 </product>
             </function>
-
+            
             <function name="aero/coefficient/Cldr">
                 <description>Roll_moment_due_to_rudder</description>
                 <product>
@@ -1634,7 +1634,7 @@
                     <property>metrics/Sw-sqft</property>
                     <property>metrics/bw-ft</property>
                     <property>fcs/rudder-pos-rad</property>
-                    <value>0.0163</value>
+                    <value>-0.30659</value>
                 </product>
             </function>
 
@@ -1863,7 +1863,7 @@
                     <property>metrics/Sw-sqft</property>
                     <property>metrics/bw-ft</property>
                     <property>fcs/aileron-pos-rad-avgd</property>
-					<value>0.45</value> <!-- Way to much adverse... -->
+                    <value>0.45</value> <!-- Way to much adverse... -->
                     <table>
                         <independentVar lookup="row">aero/alpha-wing-rad</independentVar>
                         <independentVar lookup="column">aero/beta-rad</independentVar>

--- a/c172p.xml
+++ b/c172p.xml
@@ -1634,7 +1634,7 @@
                     <property>metrics/Sw-sqft</property>
                     <property>metrics/bw-ft</property>
                     <property>fcs/rudder-pos-rad</property>
-                    <value>-0.30659</value>
+                    <value>-0.20752</value>
                 </product>
             </function>
 

--- a/c172p.xml
+++ b/c172p.xml
@@ -617,7 +617,7 @@
                     <yaw> 0.0 </yaw>
                 </orient>
                 <sense> 1 </sense>
-                <p_factor> 6 </p_factor>
+                <p_factor> 5 </p_factor>
             </thruster>
         </engine>
 
@@ -1634,7 +1634,7 @@
                     <property>metrics/Sw-sqft</property>
                     <property>metrics/bw-ft</property>
                     <property>fcs/rudder-pos-rad</property>
-                    <value>0.0147</value>
+                    <value>0.0163</value>
                 </product>
             </function>
 
@@ -1863,6 +1863,7 @@
                     <property>metrics/Sw-sqft</property>
                     <property>metrics/bw-ft</property>
                     <property>fcs/aileron-pos-rad-avgd</property>
+					<value>0.45</value> <!-- Way to much adverse... -->
                     <table>
                         <independentVar lookup="row">aero/alpha-wing-rad</independentVar>
                         <independentVar lookup="column">aero/beta-rad</independentVar>
@@ -1890,7 +1891,7 @@
                     <property>metrics/Sw-sqft</property>
                     <property>metrics/bw-ft</property>
                     <property>fcs/rudder-pos-rad</property>
-                    <value>-0.0645</value>
+                    <value>-0.0505</value>
                 </product>
             </function>
         </axis>

--- a/c172p.xml
+++ b/c172p.xml
@@ -1634,7 +1634,7 @@
                     <property>metrics/Sw-sqft</property>
                     <property>metrics/bw-ft</property>
                     <property>fcs/rudder-pos-rad</property>
-                    <value>-0.20752</value>
+                    <value>-0.1365</value>
                 </product>
             </function>
 
@@ -1863,13 +1863,13 @@
                     <property>metrics/Sw-sqft</property>
                     <property>metrics/bw-ft</property>
                     <property>fcs/aileron-pos-rad-avgd</property>
-                    <value>0.45</value> <!-- Way to much adverse... -->
+                    <value>0.75</value> <!-- Way to much adverse... -->
                     <table>
                         <independentVar lookup="row">aero/alpha-wing-rad</independentVar>
                         <independentVar lookup="column">aero/beta-rad</independentVar>
                         <tableData>
                                     -0.35        0           0.35
-                            0       -0.0166      -0.0166     -0.0166
+                            0        0.0216      -0.0216     -0.0216
                             0.070   -0.039       -0.0786     -0.039
                             0.094   -0.025       -0.0504     -0.025
                         </tableData>


### PR DESCRIPTION
Hi,
@dany93 @gilbertohasnofb @it0uchpods 

it0uchpods finally had time to revise the FDM according to his experience. This pull request is the initial work based on his comments and suggestions. It incorporates the following changes:

- P-factor adjusted to a value of 5: this is accurate for the Lycoming IO320 and calculated by measuring the rolling rate and adjusting the p-factor value to match
- Removal of aileron trim: this is artificially correcting for a value of p-factor that is much too high. Instead we should use a more accurate p-factor value.
- Tweaking of adverse yaw: this requires much testing with regards to stall and spin behaviour and could could be further tuned
- Fixing of a bug with roll due to rudder: it was reversed in that left rudder would actually cause right 
roll! Furthermore, crucially, rudder alone is now able to counter p-factor and propwash, instead of requiring aileron input as well. Previously, it was impossible to fly in a coordinated manner and also counteract both p-factor and propwash
- Propwash: and finally, propwash is now reduced which was previously much too large.

Given that this is a somewhat major change, I think this requires much testing, but I hope you'll appreciate that all these changes completely match it0uchpods' experience in the Cessna 172.

Finally, it0uchpods is currently away for a few days, so he might be delayed in responding.

⚠️ WIP DO NOT MERGE