### PR TITLE
Missing aircraft saved data, correct conditional

### DIFF
--- a/Systems/bushkit.xml
+++ b/Systems/bushkit.xml
@@ -189,8 +189,8 @@ Extra weight and drag due to bush wheels, floats and aircraft with 180 hp engine
                 <product>
                     <value>1.0</value>
                     <ge>
-                        <value>3.0</value>
                         <property>bushkit</property>
+                        <value>3.0</value>
                     </ge>
                     <le>
                         <property>bushkit</property>

--- a/Systems/bushkit.xml
+++ b/Systems/bushkit.xml
@@ -188,10 +188,10 @@ Extra weight and drag due to bush wheels, floats and aircraft with 180 hp engine
             <function>
                 <product>
                     <value>1.0</value>
-                    <ge>
-                        <property>bushkit</property>
+                    <le>
                         <value>3.0</value>
-                    </ge>
+                        <property>bushkit</property>
+                    </le>
                     <le>
                         <property>bushkit</property>
                         <value>4.0</value>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -302,6 +302,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <path>/controls/climate-control/overhead-vent-front-left</path>
             <path>/controls/climate-control/overhead-vent-front-right</path>
             <path>/fdm/jsbsim/running</path>
+            <path>/fdm/jsbsim/bushkit</path>
             <path>/consumables/fuel/save-fuel-state</path>
             <path>/consumables/fuel/contamination_allowed</path>
             <path>/instrumentation/save-switches-state</path>


### PR DESCRIPTION
Fixes #1267

This fixes a persistent data issue. When doing a seaport relocation it is necessary for the ``` fdm/jsbsim/bushkit ``` property ro be persistent.

The second part of the PR addressee the structure of a conditional originally looked to be wrong, but on closer examination it was technically correct. It was changed but incorrectly (by me, I forgot to change the order of the comparison). It is now changed again but the correct way. We could leave it like it was originally but it was a bit confusing. What I am not sure of is if the original way was necessary because of a little known issue of
``` var <  const ... var > const ```
needing to be written as
``` var < const ... const < var ```
I think I originally changed it (incorrectly because I forgot to flip the order) when I noticed the condition didn't appear to work correctly. I am now wondering if it not working was due to this unknown bug we are currently trying to address.

So I would rather put it back to the way @onox set it up originally if there is any doubt of this new way working correctly.
Just know this isn't the underlying problem to the bug we are dealing with now in the hydro system. Unless it is a new inherent bug due to some change in how this logic works in the core code. I have tried every iteration I could think of to test this including wrapping the ``` ge/le ``` in ``` and ```and also putting it back to the way @onox originally set it up.