### PR TITLE
Added fallback model support

### DIFF
--- a/c172p-float-set.xml
+++ b/c172p-float-set.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1"?>
+<?xml version="1.0"?>
 <!--
 ************************************************************************
 c172p simulation configuration. This files ties together all the components

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -68,6 +68,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 
         <model>
             <path archive="y">Aircraft/c172p/Models/c172p.xml</path>
+            <fallback-model-index type="int">1</fallback-model-index>
 
             <!-- Default livery -->
             <livery>


### PR DESCRIPTION
The fallback model (in fgdata) for the C172 is index 1; this allows use of the low detail option and avoids blue/yellow glider when the model is loading (over MP).

Also fixed an invalid XML definition; the xml tag refers to the xml version not the file version and must be 1.0