### PR TITLE
Load GPS only once and translate instead

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -164,31 +164,48 @@
             <z-m> 0.08948</z-m>
             <heading-deg>-19.0</heading-deg>
         </offsets>
-        <condition>
-            <not>
-                <equals>
-                   <property alias="/params/bushkit"/>
-                   <value>4</value>
-                </equals>
-            </not>
-        </condition>
+    </model>
+    <animation>
+        <type>translate</type>
+        <object-name>Garmin196-GPS-non-Canvas</object-name>
+        <property>/Interior/Panel/Instruments/garmin196/move</property>
+        <factor>0.1</factor>
+        <axis>
+            <x>0.0</x>
+            <y>1.0</y>
+            <z>0.0</z>
+        </axis>
+    </animation>
+
+    <!-- Canvas local Garmin 196 GPS -->
+    <!--<model>
+        <name>Garmin196-GPS</name>
+        <path>Interior/Panel/garmin196/garmin196.xml</path>
+        <offsets>
+            <x-m>-0.4</x-m>
+            <y-m>0.36</y-m>
+            <z-m>0.205</z-m>
+            <heading-deg>-12.0</heading-deg>
+        </offsets>
     </model>
     <model>
-        <name>Garmin196-GPS-non-Canvas</name>
-        <path>Interior/Panel/Instruments/garmin196/garmin196.xml</path>
+        <name>Garmin196-GPS-support</name>
+        <path>Interior/Panel/garmin196/garmin196_support.xml</path>
         <offsets>
-            <x-m>-0.305</x-m>
-            <y-m> 0.36584</y-m>
-            <z-m> 0.08948</z-m>
-            <heading-deg>-19.0</heading-deg>
+            <x-m>-0.4</x-m>
+            <y-m>0.36</y-m>
+            <z-m>0.205</z-m>
+            <heading-deg>-12.0</heading-deg>
         </offsets>
-        <condition>
-            <equals>
-               <property alias="/params/bushkit"/>
-               <value>4</value>
-            </equals>
-        </condition>
     </model>
+    <animation>
+        <type>select</type>
+        <object-name>Garmin196-GPS</object-name>
+        <object-name>Garmin196-GPS-support</object-name>
+        <condition>
+            <property>/sim/model/c172p/garmin196-visible</property>
+        </condition>
+    </animation>-->
 
     <model>
         <name>GPS-Model</name>
@@ -315,36 +332,6 @@
             </not>
         </condition>
     </animation>
-
-    <!-- Canvas local Garmin 196 GPS -->
-    <!--<model>
-        <name>Garmin196-GPS</name>
-        <path>Interior/Panel/garmin196/garmin196.xml</path>
-        <offsets>
-            <x-m>-0.4</x-m>
-            <y-m>0.36</y-m>
-            <z-m>0.205</z-m>
-            <heading-deg>-12.0</heading-deg>
-        </offsets>
-    </model>
-    <model>
-        <name>Garmin196-GPS-support</name>
-        <path>Interior/Panel/garmin196/garmin196_support.xml</path>
-        <offsets>
-            <x-m>-0.4</x-m>
-            <y-m>0.36</y-m>
-            <z-m>0.205</z-m>
-            <heading-deg>-12.0</heading-deg>
-        </offsets>
-    </model>
-    <animation>
-        <type>select</type>
-        <object-name>Garmin196-GPS</object-name>
-        <object-name>Garmin196-GPS-support</object-name>
-        <condition>
-            <property>/sim/model/c172p/garmin196-visible</property>
-        </condition>
-    </animation>-->
 
     <nasal>
         <load>

--- a/Systems/bushkit.xml
+++ b/Systems/bushkit.xml
@@ -183,6 +183,16 @@ Extra weight and drag due to bush wheels, floats and aircraft with 180 hp engine
         </switch>
     </channel>
 
+    <channel name="GPS-placement">
+        <switch name="gps-placement">
+            <default value="0"/>
+            <test logic="AND" value="1">
+                bushkit EQ 4
+            </test>
+            <output>/Interior/Panel/Instruments/garmin196/move</output>
+        </switch>
+    </channel>
+
     <channel name="JSBSim hydrodynamics integration">
         <fcs_function name="tmp/floats-enabled-norm">
             <function>


### PR DESCRIPTION
Fixes #1255 

This is finished, We load the GPS model once and use a translate animation to move it if the amphibious bushkit is selected.

The interior shadow when in amphibious mode is slightly off, but not enough to warrant major effort required to fix it, if it is even possible.

If @legoboyvdlp or @gilbertohasnofb can merge this after testing I will cherry pick it to the release branch.