### PR TITLE
Issue 1286

### DIFF
--- a/Systems/instruments.xml
+++ b/Systems/instruments.xml
@@ -411,6 +411,19 @@
     </filter>
 
     <logic>
+        <name>Turn Indicator Serviceable</name>
+        <input>
+            <greater-than>
+                <property>systems/electrical/outputs/turn-coordinator</property>
+                <value>6.0</value>
+            </greater-than>
+        </input>
+        <output>
+            <property>instrumentation/turn-coordinator/serviceable</property>
+        </output>
+    </logic>
+
+    <logic>
         <name>Amphibious Panel Lights On/Off</name>
         <input>
             <and>

--- a/Systems/mooring-pos.xml
+++ b/Systems/mooring-pos.xml
@@ -717,4 +717,20 @@ Wayne Bragg/c172p-detailed, April 2018
         <heading-deg type="double">245.0</heading-deg>
     </seaplane>
 
+    <!-- Brooks Seaplane Base S76, Coeur D Alene Airport KCOE Idaho -->
+    <seaplane n="60">
+        <airport-id type="string">KCOE</airport-id>
+        <latitude-deg type="double">47.66</latitude-deg>
+        <longitude-deg type="double">-116.79</longitude-deg>
+        <heading-deg type="double">180.0</heading-deg>
+    </seaplane>
+
+    <!-- Lake Pend Orielle S96, Idaho -->
+    <seaplane n="61">
+        <airport-id type="string">KSZT</airport-id>
+        <latitude-deg type="double">48.216944</latitude-deg>
+        <longitude-deg type="double">-116.367778</longitude-deg>
+        <heading-deg type="double">0.0</heading-deg>
+    </seaplane>
+
 </PropertyList>


### PR DESCRIPTION
Fixes #1286
Incidental - I didn't feel like creating a separate issue just to add a couple new mooring locations. I hope that isn't an issue for anyone.

If you all want to wait to merge this, I did a complete breaker and electrical system for the amphibious gear select, gear advisory and gear hydraulics for the pa18. I can add it to the c172p conditioned on the amphibious being selected.
Right now, in the c172p, I think it is simply tied into the master switch and alt breaker.