### PR TITLE
Amphibious gear switch not to trigger repair timer if pontoon damaged

### DIFF
--- a/Nasal/physics.nas
+++ b/Nasal/physics.nas
@@ -195,8 +195,10 @@ setlistener("/fdm/jsbsim/wing-damage/right-wing", func (n) {
         killengine();
 }, 0, 0);
 
-setlistener("/controls/gear/gear-down-command", func (n) {
-    setprop("/fdm/jsbsim/damage/repairing", 1);
-    bushkit_changed_timer.restart(bushkit_change_timeout);
+setlistener("controls/gear/gear-down-command", func (n) {
+    if (getprop("/fdm/jsbsim/pontoon-damage/left-pontoon")==0 and getprop("/fdm/jsbsim/pontoon-damage/right-pontoon")==0) {
+        setprop("/fdm/jsbsim/damage/repairing", 1);
+        bushkit_changed_timer.restart(bushkit_change_timeout);
+    }
 }, 0, 0);
 


### PR DESCRIPTION
Fixes #1290 

I need to merge this and back port to our 2019.1 release immediately as I am holding up 2019.1 at remote.
I found this after one last test, after I merged the main issue https://github.com/c172p-team/c172p/pull/1289
Total apologies for doing this out of our normal procedures.