### PR TITLE
Issue 1293

### DIFF
--- a/Nasal/physics.nas
+++ b/Nasal/physics.nas
@@ -165,6 +165,7 @@ var set_bushkit = func (bushkit) {
 # changing to the last bush kit option.
 var bushkit_changed_timer = maketimer(bushkit_change_timeout, func {
     setprop("/fdm/jsbsim/damage/repairing", 0);
+    setprop("/fdm/jsbsim/damage/traversing", 0);
 });
 bushkit_changed_timer.singleShot = 1;
 
@@ -197,7 +198,7 @@ setlistener("/fdm/jsbsim/wing-damage/right-wing", func (n) {
 
 setlistener("controls/gear/gear-down-command", func (n) {
     if (getprop("/fdm/jsbsim/pontoon-damage/left-pontoon")==0 and getprop("/fdm/jsbsim/pontoon-damage/right-pontoon")==0) {
-        setprop("/fdm/jsbsim/damage/repairing", 1);
+        setprop("/fdm/jsbsim/damage/traversing", 1);
         bushkit_changed_timer.restart(bushkit_change_timeout);
     }
 }, 0, 0);

--- a/Systems/c172p-damage.xml
+++ b/Systems/c172p-damage.xml
@@ -531,6 +531,7 @@
             <test logic="OR" value="0">
                 settings/damage EQ 0
                 damage/repairing EQ 1
+                damage/traversing EQ 1
                 simulation/sim-time-sec LT 0.25
             </test>
             <test logic="AND" value="0">
@@ -573,6 +574,7 @@
             <test logic="OR" value="0">
                 settings/damage EQ 0
                 damage/repairing EQ 1
+                damage/traversing EQ 1
                 simulation/sim-time-sec LT 0.25
             </test>
             <test logic="AND" value="0">


### PR DESCRIPTION
Fixes #1293 

Change repairing flag to a traversing flag. This allows for gear traversing without causing damage. Repairing flag is no longer used so it eliminates fixing of other damage on gear switch event.