### PR TITLE
Wkitty42 flashlight patch 1

### DIFF
--- a/c172-help.xml
+++ b/c172-help.xml
@@ -13,7 +13,7 @@
         <desc>Toggle yokes hidden/visible</desc>
     </key>
     <key>
-        <name>f</name>
+        <name>f/F</name>
         <desc>Toggle flashlight white/red/off</desc>
     </key>
     <key>

--- a/c172p-keyboard.xml
+++ b/c172p-keyboard.xml
@@ -66,6 +66,16 @@
         </binding>
     </key>
 
+    <key n="102">
+        <name>f</name>
+        <desc>Toggle flashlight</desc>
+        <repeatable type="bool">true</repeatable>
+        <binding>
+            <command>nasal</command>
+            <script>c172p.toggle_flashlight()</script>
+        </binding>
+    </key>
+
     <key n="108">
         <name>l</name>
         <desc>Increase Panel lighting</desc>


### PR DESCRIPTION
the in-sim aircraft help said 'f' was the toggle for the flashlight but only 'F' was defined in the keyboard bindings. this commit makes both keys valid as the flashlight toggle so we don't have to fumble about in the dark ;)