### PR TITLE
Issue 1330

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -5274,7 +5274,7 @@
     <animation>
         <type>knob</type>
         <object-name>RudderTrimKnob</object-name>
-        <property>controls/flight/rudder-trim-knob</property>
+        <property>controls/flight/rudder-trim</property>
         <factor>40</factor>
         <drag-direction>horizontal</drag-direction>
         <offset-deg>0</offset-deg>
@@ -5291,7 +5291,7 @@
         <action>
             <binding>
                 <command>property-adjust</command>
-                <property>controls/flight/rudder-trim-knob</property>
+                <property>controls/flight/rudder-trim</property>
                 <factor>0.002</factor>
                 <min>-.18</min>
                 <max>.18</max>
@@ -5303,7 +5303,7 @@
                 <command>set-tooltip</command>
                 <label>Rudder trim: %3.3f</label>
                 <tooltip-id>rudder-trim</tooltip-id>
-                <property>controls/flight/rudder-trim-knob</property>
+                <property>controls/flight/rudder-trim</property>
             </binding>
         </hovered>
     </animation>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -5123,7 +5123,7 @@
             <binding>
                 <command>property-adjust</command>
                 <property>/controls/engines/current-engine/throttle</property>
-                <factor>0.05</factor>
+                <factor>0.02</factor>
                 <min>0</min>
                 <max>1</max>
                 <wrap>0</wrap>
@@ -5200,7 +5200,7 @@
             <binding>
                 <command>property-adjust</command>
                 <property>controls/engines/current-engine/mixture</property>
-                <factor>0.05</factor>
+                <factor>0.02</factor>
                 <min>0</min>
                 <max>1</max>
                 <wrap>0</wrap>
@@ -5223,7 +5223,7 @@
         <type>knob</type>
         <object-name>TrimWheel</object-name>
         <property>controls/flight/elevator-trim</property>
-        <factor>-80</factor>
+        <factor>-360</factor>
         <drag-direction>vertical</drag-direction>
         <axis>
             <x>0.0</x>
@@ -5239,7 +5239,7 @@
             <binding>
                 <command>property-adjust</command>
                 <property>controls/flight/elevator-trim</property>
-                <factor>0.01</factor>
+                <factor>0.001</factor>
                 <min>-1</min>
                 <max>1</max>
                 <wrap>0</wrap>
@@ -5248,7 +5248,7 @@
         <hovered>
             <binding>
                 <command>set-tooltip</command>
-                <label>Elevator trim: %3.2f</label>
+                <label>Elevator trim: %3.3f</label>
                 <tooltip-id>pitch-trim</tooltip-id>
                 <property>controls/flight/elevator-trim</property>
             </binding>
@@ -5292,7 +5292,7 @@
             <binding>
                 <command>property-adjust</command>
                 <property>controls/flight/rudder-trim-knob</property>
-                <factor>0.01</factor>
+                <factor>0.002</factor>
                 <min>-.18</min>
                 <max>.18</max>
                 <wrap>false</wrap>
@@ -5301,7 +5301,7 @@
         <hovered>
             <binding>
                 <command>set-tooltip</command>
-                <label>Rudder trim: %3.2f</label>
+                <label>Rudder trim: %3.3f</label>
                 <tooltip-id>rudder-trim</tooltip-id>
                 <property>controls/flight/rudder-trim-knob</property>
             </binding>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -5223,7 +5223,7 @@
         <type>knob</type>
         <object-name>TrimWheel</object-name>
         <property>controls/flight/elevator-trim</property>
-        <factor>-360</factor>
+        <factor>-80</factor>
         <drag-direction>vertical</drag-direction>
         <axis>
             <x>0.0</x>

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -318,7 +318,8 @@ var switches_save_state = func {
         setprop("/environment/aircraft-effects/cabin-air-set", 0.0);
         setprop("/consumables/fuel/tank[0]/selected", 1);
         setprop("/consumables/fuel/tank[1]/selected", 1);
-        setprop("/controls/flight/rudder-trim-knob", 0.0);
+        if (getprop("/sim/model/c172p/ruddertrim-visible"))
+          setprop("/controls/flight/rudder-trim", 0);
     };
 };
 
@@ -664,6 +665,10 @@ setlistener("/sim/signals/fdm-initialized", func {
     # Listening for lightning strikes
     setlistener("/environment/lightning/lightning-pos-y", thunder);
 
+    if (!getprop("sim/model/c172p/ruddertrim-visible")){
+           setprop("/controls/flight/rudder-trim", 0.02);
+    }
+
     reset_system();
 
     var onground = getprop("/sim/presets/onground") or "";
@@ -737,3 +742,12 @@ setprop("/sim/startup/season-winter", getprop("/sim/startup/season") == "winter"
 setlistener("/sim/startup/season", func (node) {
     setprop("/sim/startup/season-winter", node.getValue() == "winter");
 }, 0, 0);
+
+# rudder trim setting changes, manual or automatic
+setlistener("/sim/model/c172p/ruddertrim-visible", func (node) {
+    if (node.getValue()) {
+        setprop("/controls/flight/rudder-trim", 0);
+    } else
+        setprop("/controls/flight/rudder-trim", 0.02);
+}, 0, 0);
+

--- a/c172-sound.xml
+++ b/c172-sound.xml
@@ -1295,7 +1295,7 @@
             <name>dial-rudder-trim-</name>
             <mode>in-transit</mode>
             <path>Sounds/rudder-trim.wav</path>
-            <property>/controls/flight/rudder-trim-knob</property>
+            <property>/controls/flight/rudder-trim</property>
             <position>
                 <x>-0.3660</x>
                 <y>0.0500</y>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -561,7 +561,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 
         <!-- Fix scrolling direction of knobs -->
         <mouse>
-            <invert-mouse-wheel type="bool">true</invert-mouse-wheel>
+            <invert-mouse-wheel type="bool">false</invert-mouse-wheel>
         </mouse>
 
         <gui>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -320,7 +320,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <path>/sim/current-view/user/pitch-offset-deg</path>
             <path>/sim/current-view/user/default-field-of-view-deg</path>
             <path>/sim/model/c172p/ruddertrim-visible</path>
-            <path>/controls/flight/rudder-trim-knob</path>
+            <path>/controls/flight/rudder-trim</path>
         </aircraft-data>
 
         <current-view>
@@ -591,8 +591,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
     <controls>
         <flight>
             <aileron-trim type="double">0.022</aileron-trim>
-            <rudder-trim type="double">0.02</rudder-trim>
-            <rudder-trim-knob type="double">0.0</rudder-trim-knob>
+            <rudder-trim type="double">0.0</rudder-trim>
             <freeze-yoke type="bool">false</freeze-yoke>
             <aileron-cmd type="double">0.0</aileron-cmd>
             <elevator-cmd type="double">0.0</elevator-cmd>

--- a/c172p.xml
+++ b/c172p.xml
@@ -810,19 +810,6 @@
                 <output>/sim/model/c172p/cockpit/pedals-rudder</output>
             </kinematic>
 
-            <fcs_function name="fcs/yaw-trim-cockpit">
-                <function>
-                    <table>
-                        <independentVar lookup="row">/controls/flight/rudder-trim-knob</independentVar>
-                        <tableData>
-                            -.18    0.20
-                            0.00    0.00
-                             .18   -0.20
-                        </tableData>
-                    </table>
-                </function>
-            </fcs_function>
-
             <summer name="Yaw Trim Sum">
                 <input>fcs/rudder-cmd-norm-filtered</input>
                 <input>fcs/yaw-trim-cmd-norm</input>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -362,14 +362,6 @@
                 <binding>
                     <command>dialog-apply</command>
                 </binding>
-                <binding>
-                    <command>nasal</command>
-                    <script>
-                        if (!getprop("/sim/model/c172p/ruddertrim-visible")) {
-                            setprop("/controls/flight/rudder-trim-knob", 0);
-                        }
-                    </script>
-                </binding>
             </checkbox>
 
         </group>


### PR DESCRIPTION
Closes #1330

The idea behind this PR is:

* any lever that moves in/out or up/down will match the direction of the scroll
  - scroll up: raise flaps
  - scroll up: move throttle and mixture in
  - scroll up: move trim wheel up, lowering the nose
* for knobs that turn on a different plane (e.g. all gauge knobs), scrolling up means increase of value, just like any GUI out there (e.g. volume knobs on OS's). This will also match other flight simulators as far as I know.
* I also slowed down the animation of the scroll wheel so that it looks more smooth, it was moving too much for each small step of trim and did not look too good.