### PR TITLE
Issue 1344

### DIFF
--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -323,6 +323,45 @@ var engine_coughing = func(){
 
 var coughing_timer = maketimer(1, engine_coughing);
 
+# ====== Engine starting actions ======
+var engine_starting = props.globals.initNode("/engines/engine/starting", 0, "BOOL");
+setlistener("/engines/engine/running", func(ngn){
+    if (ngn.getValue() and !getprop("/engines/engine[0]/coughing")) {
+        engine_starting.setValue(1);
+        var timer = maketimer(1, func(){
+            engine_starting.setValue(0);
+        });
+        timer.singleShot = 1; # timer will only be run once
+        timer.start();
+    } else {
+        engine_starting.setValue(0);
+    }
+},0,0);
+
+setlistener("/engines/engine/starting", func(ngn){
+    # Eye-candy: when engine starts, let the view shake a bit
+    if (ngn.getValue() and getprop("/sim/current-view/internal")) {
+        var curX = getprop("/sim/current-view/x-offset-m");
+        var xtimer = maketimer(0.05, func(){
+            interpolate("/sim/current-view/x-offset-m", curX-0.0015+rand()*0.003, 0.05);
+        });
+        xtimer.start();
+        var curY = getprop("/sim/current-view/y-offset-m");
+        var ytimer = maketimer(0.05, func(){
+            interpolate("/sim/current-view/y-offset-m", curY-0.0015+rand()*0.003, 0.05);
+        });
+        ytimer.start();
+        var stoptimer = maketimer(0.8, func(){
+           xtimer.stop();
+           ytimer.stop();
+           interpolate("/sim/current-view/x-offset-m", curX, 0.1);
+           interpolate("/sim/current-view/y-offset-m", curY, 0.1);
+        });
+        stoptimer.singleShot = 1;
+        stoptimer.start();
+    }
+}, 0, 0);
+
 # ========== Main loop ======================
 
 var update = func {

--- a/Systems/KAP140.xml
+++ b/Systems/KAP140.xml
@@ -7,10 +7,58 @@
 
 <PropertyList>
 
+	<filter>
+        <name>heading bug backcourse</name>
+        <debug>false</debug>
+        <type>gain</type>
+        <input>
+            <condition>
+                <less-than>
+                    <property>autopilot/settings/heading-bug-deg</property>
+                    <value>180</value>
+                </less-than>
+            </condition>
+            <expression>
+                <sum>
+                    <property>autopilot/settings/heading-bug-deg</property>
+                    <value>180</value>
+                </sum>
+            </expression>
+        </input>
+        <input>
+            <expression>
+                <sum>
+                    <value>-180</value>
+                    <property>autopilot/settings/heading-bug-deg</property>
+                </sum>
+            </expression>
+        </input>
+        <output>
+            <property>autopilot/settings/heading-bug-deg-backcourse</property>
+        </output>
+    </filter>
+
     <filter>
         <name>heading bug error computer/normalizer</name>
         <debug>false</debug>
         <type>gain</type>
+
+        <!-- REV mode -->
+        <input>
+            <condition>
+                <equals>
+                    <property>/autopilot/KAP140/locks/rev-hold</property>
+                    <value type="bool">true</value>
+                </equals>
+            </condition>
+            <property>autopilot/settings/heading-bug-deg-backcourse</property>
+            <offset>
+                <property>instrumentation/heading-indicator/indicated-heading-deg</property>
+                <scale>-1.0</scale>
+            </offset>
+        </input>
+
+        <!-- Other modes -->
         <input>
             <property>autopilot/settings/heading-bug-deg</property>
             <offset>


### PR DESCRIPTION
This adds a REV mode to the KAP140. From the c182s/t and @hbeni thank you.
Needs tested by someone familiar with KAP140 operations.

NOTE:
Hum, I don't know how or why the Engine shaking effect is included in this. I pulled a fresh copy from the repository, then added the KAP140 REV mode code. Somehow it picked up the "Engine Shaking" commit? I'm not sure how to fix this other than delete it and try again?