### PR TITLE
Add aerotow support

### DIFF
--- a/c172-help.xml
+++ b/c172-help.xml
@@ -17,6 +17,10 @@
         <desc>Toggle flashlight white/red/off</desc>
     </key>
     <key>
+        <name>O</name>
+        <desc>Open aerotow-hook</desc>
+    </key>
+    <key>
         <name>P</name>
         <desc>Toggle high resolution panel on/off</desc>
     </key>

--- a/c172p-keyboard.xml
+++ b/c172p-keyboard.xml
@@ -49,12 +49,12 @@
 
     <key n="79">
         <name>O</name>
-        <desc>Toggle Dome Lighting</desc>
+        <desc>Open aerotow-hook</desc>
         <binding>
-            <command>nasal</command>
-            <script>c172p.toggle_domelight()</script>
+          <command>nasal</command>
+          <script>towing.releaseHitch("aerotow")</script>
         </binding>
-    </key>
+      </key>
 
     <key n="70">
         <name>F</name>
@@ -87,6 +87,15 @@
             <min>0</min>
             <max>1.0</max>
             <wrap>0</wrap>
+        </binding>
+    </key>
+
+    <key n="111">
+        <name>o</name>
+        <desc>Toggle Dome Lighting</desc>
+        <binding>
+            <command>nasal</command>
+            <script>c172p.toggle_domelight()</script>
         </binding>
     </key>
 

--- a/c172p-main.xml
+++ b/c172p-main.xml
@@ -581,6 +581,20 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 
       <state include="states/c172p-automatic-overlay.xml" n="0"/>
 
+      <hitches>
+        <aerotow>
+            <force_name_jsbsim type="string">hitch</force_name_jsbsim>
+            <force-is-calculated-by-other type="bool">true</force-is-calculated-by-other>
+            <mp-auto-connect-period type="float">1.0</mp-auto-connect-period>
+            <!-- OPTIONAL
+                <decoupled-force-and-rope-locations type="bool">true</decoupled-force-and-rope-locations>
+                <local-pos-x type="float">1.5</local-pos-x>
+                <local-pos-y type="float"> 0.00</local-pos-y>
+                <local-pos-z type="float">-0.3</local-pos-z>
+            -->
+        </aerotow>
+      </hitches>
+
     </sim>
 
     <aircraft>

--- a/c172p.xml
+++ b/c172p.xml
@@ -2118,6 +2118,18 @@
             </direction>
         </force>
 
+        <force name="hitch" frame="BODY" unit="LBS" >
+            <location unit="M">
+                <x> 4.7116</x>
+                <y> 0.0000</y>
+                <z>-0.6663</z>
+            </location>
+            <direction>
+                <x>0.0</x>
+                <y>0.0</y>
+                <z>0.0</z>
+            </direction>
+        </force>
     </external_reactions>
 
     <system file="bushkit"/>


### PR DESCRIPTION
Adds standard aerotow capability
- Glider presses `CTRL+O` behind the plane to hook into the Cessna
- Cessna pilot can release hook anytime by pressing `SHIFT-O`
  (Moved Domelight keybind `SHIFT-O` to `o`, as `SHIFT-O` is the default aerotow release)

After merging:
- add c172 to the [towing overview](https://wiki.flightgear.org/Howto:Do_aerotow_over_the_net)
- add `aircraft/Glider tug` to [C172P infobox template type](https://wiki.flightgear.org/w/index.php?title=Cessna_172P/info&action=edit)
- add a short section to the [C172P wiki page](https://wiki.flightgear.org/C172) that it can aerotow (example: [Cub](https://wiki.flightgear.org/Piper_J3_Cub#Aerotowing))

----
Tested with ASK21:
![Screenshot_20210426_144339](https://user-images.githubusercontent.com/13608602/116084822-7735f300-a69e-11eb-9197-ad6f7eda59c3.jpg)
![Screenshot_20210426_144800](https://user-images.githubusercontent.com/13608602/116084820-769d5c80-a69e-11eb-88af-dd8f20138bd2.jpg)



----
Fix #1361