### PR TITLE
Bug in fuel logic

### DIFF
--- a/Systems/fuel.xml
+++ b/Systems/fuel.xml
@@ -18,15 +18,28 @@ Fuel system for 2 different engines at choice, JSBSim FDM
 
     <channel name="Float Chamber">
         <!-- Give tank[4] priority regardless of engine is used -->
+        <switch name="Float Chamber From Engine 0">
+            <output>propulsion/tank[4]/fuel/to-engine0</output>
+            <default value="0"/>
+            <test logic="AND" value="1">
+                /controls/engines/active-engine EQ 0
+                /engines/active-engine/killed EQ 0
+            </test>
+        </switch>
+        <switch name="Float Chamber From Engine 1">
+            <output>propulsion/tank[4]/fuel/to-engine1</output>
+            <default value="0"/>
+            <test logic="AND" value="1">
+                /controls/engines/active-engine EQ 1
+                /engines/active-engine/killed EQ 0
+            </test>
+        </switch>
         <switch name="Float Chamber">
             <output>propulsion/tank[4]/priority</output>
             <default value="0"/>
             <test logic="OR" value="1">
-                /controls/engines/active-engine EQ 0
-                /controls/engines/active-engine EQ 1
-            </test>
-            <test logic="AND" value="1">
-                /engines/active-engine/killed EQ 0
+                propulsion/tank[4]/fuel/to-engine0 EQ 1
+                propulsion/tank[4]/fuel/to-engine1 EQ 1
             </test>
         </switch>
     </channel>


### PR DESCRIPTION
Fixes #1371 

@legoboyvdlp this fixes and issue where when in the "Allow Damage" mode and you crash (like nose and prop damage, front gear) the engine doesn't stop anymore. This fixes it. See the #1371 issue for explanation and if you know why the original logic doesn't work, please explain.

Anyway, this new logic does work and once merged needs to be cherry picked to 2020.3