### PR TITLE
Allow default action in viewfrom in mouse manager

### DIFF
--- a/Systems/views.xml
+++ b/Systems/views.xml
@@ -45,10 +45,6 @@
                     <value>lookat</value>
                 </equals>
                 <not-equals>
-                    <property>/sim/current-view/type</property>
-                    <value>lookfrom</value>
-                </not-equals>
-                <not-equals>
                     <property>/sim/current-view/name</property>
                     <value>Tower View</value>
                 </not-equals>

--- a/c172p-mice.xml
+++ b/c172p-mice.xml
@@ -43,6 +43,19 @@
                         gui.popupTip(sprintf("%d meter", abs(getprop("/sim/current-view/z-offset-m"))));
                     </script>
                 </binding>
+               <binding n="2">
+                    <condition>
+                        <and>
+                            <not>
+                                <property>/sim/current-view/can-change-z-offset</property>
+                            </not>
+                            <property>/devices/status/mice/mouse[0]/button[2]</property>
+                            <not><property>/sim/mouse/right-button-mode-cycle-enabled</property></not>
+                        </and>
+                    </condition>
+                    <command>nasal</command>
+                    <script>view.decrease()</script>
+                </binding>
             </button>
 
             <button n="4">
@@ -65,6 +78,19 @@
 
                         gui.popupTip(sprintf("%d meter", abs(getprop("/sim/current-view/z-offset-m"))));
                     </script>
+                </binding>
+                <binding n="2">
+                    <condition>
+                        <and>
+                            <not>
+                                <property>/sim/current-view/can-change-z-offset</property>
+                            </not>
+                            <property>/devices/status/mice/mouse[0]/button[2]</property>
+                            <not><property>/sim/mouse/right-button-mode-cycle-enabled</property></not>
+                        </and>
+                    </condition>
+                    <command>nasal</command>
+                    <script>view.increase()</script>
                 </binding>
             </button>
         </mode>


### PR DESCRIPTION
Fixes #1373

Adds back in the default mouse action when in a viewfrom view mode.

@Megaf 
Please pull and test this.

@legoboyvdlp after @Megaf tests and confirms this works, would you mind testing what you can as far as normal views you use and if satisfied, merge and cherry pick again to 2020.3.
Thanks