### PR TITLE
Add multi-key support for FG1000

### DIFF
--- a/c172p-fg1000-gfc-set.xml
+++ b/c172p-fg1000-gfc-set.xml
@@ -174,4 +174,9 @@ model, instrument panel, and external 3D model.
             </fuel>
         </jsbsim>
     </fdm>
+    <input>
+        <keyboard>
+            <multikey include="Aircraft/Instruments-3d/FG1000/fg1000-multikey.xml"/>
+        </keyboard>
+    </input>
 </PropertyList>

--- a/c172p-fg1000-kap-set.xml
+++ b/c172p-fg1000-kap-set.xml
@@ -300,4 +300,9 @@ model, instrument panel, and external 3D model.
             </fuel>
         </jsbsim>
     </fdm>
+    <input>
+        <keyboard>
+            <multikey include="Aircraft/Instruments-3d/FG1000/fg1000-multikey.xml"/>
+        </keyboard>
+    </input>
 </PropertyList>


### PR DESCRIPTION
As we have at https://wiki.flightgear.org/FG1000#Multikey_Support, the FG1000 should support multi-keys.