### PR TITLE
Fix hpa displayed values at KAP140 on c172p

### DIFF
--- a/Models/Interior/Panel/Instruments/kap140/KAP140TwoAxisAlt.xml
+++ b/Models/Interior/Panel/Instruments/kap140/KAP140TwoAxisAlt.xml
@@ -639,8 +639,8 @@ properties' values.
         <type>textranslate</type>
         <object-name>hpa-digit2</object-name>
         <property>/autopilot/KAP140/settings/baro-setting-hpa</property>
-        <factor>0.1</factor>
-        <step>1</step>
+        <factor>0.0001</factor>
+        <step>1000</step>
         <bias>0.0005</bias>
         <axis>
             <x>1</x>
@@ -653,22 +653,8 @@ properties' values.
         <type>textranslate</type>
         <object-name>hpa-digit3</object-name>
         <property>/autopilot/KAP140/settings/baro-setting-hpa</property>
-        <factor>1</factor>
-        <step>0.1</step>
-        <bias>0.0005</bias>
-        <axis>
-            <x>1</x>
-            <y>0</y>
-            <z>0</z>
-        </axis>
-    </animation>
-
-    <animation>
-        <type>textranslate</type>
-        <object-name>hpa-digit3</object-name>
-        <property>/autopilot/KAP140/settings/baro-setting-hpa</property>
-        <factor>10</factor>
-        <step>0.01</step>
+        <factor>0.001</factor>
+        <step>100</step>
         <bias>0.0005</bias>
         <axis>
             <x>1</x>
@@ -681,8 +667,22 @@ properties' values.
         <type>textranslate</type>
         <object-name>hpa-digit4</object-name>
         <property>/autopilot/KAP140/settings/baro-setting-hpa</property>
-        <factor>100</factor>
-        <step>0.001</step>
+        <factor>0.01</factor>
+        <step>10</step>
+        <bias>0.0005</bias>
+        <axis>
+            <x>1</x>
+            <y>0</y>
+            <z>0</z>
+        </axis>
+    </animation>
+
+    <animation>
+        <type>textranslate</type>
+        <object-name>hpa-digit5</object-name>
+        <property>/autopilot/KAP140/settings/baro-setting-hpa</property>
+        <factor>0.1</factor>
+        <step>1</step>
         <bias>0.0005</bias>
         <axis>
             <x>1</x>


### PR DESCRIPTION
Fixing rather a typo so as the right value of hpa to be displayed when flying a c172p of release 2020.3