### PR TITLE
FG1000 audio panel and radio bug fixes

### DIFF
--- a/Models/Interior/Panel/c172sp-panel/c172sp.xml
+++ b/Models/Interior/Panel/c172sp-panel/c172sp.xml
@@ -3456,7 +3456,6 @@
             <binding>
                 <command>nasal</command>
                 <script>
-                    #kap140.altButton();
                     c172p.click("kap140");
                 </script>
             </binding>
@@ -3467,11 +3466,12 @@
             <binding>
                 <command>nasal</command>
                 <script>
-                    var power = getprop("/instrumentation/audio-panel/dme-btn");
-                    if (power) {
+                    var adf_operable = getprop("/instrumentation/adf/operable");
+					var button_on = getprop("/instrumentation/audio-panel/adf-btn");
+                    if (adf_operable and button_on) {
                         setprop("/instrumentation/adf/ident-audible", 1);
                     } else {
-                        setprop(/instrumentation/adf/ident-audible", 0);
+                        setprop("/instrumentation/adf/ident-audible", 0);
                     }
                 </script>
             </binding>
@@ -4003,7 +4003,7 @@
             </binding>
             <binding>
                 <command>property-toggle</command>
-                <property>/instrumentation/nav/power-btn</property>
+                <property>/instrumentation/nav/audio-btn</property>
             </binding>
         </action>
         <hovered>
@@ -4057,7 +4057,7 @@
             </binding>
             <binding>
                 <command>property-toggle</command>
-                <property>/instrumentation/nav1/power-btn</property>
+                <property>/instrumentation/nav[1]/audio-btn</property>
             </binding>
         </action>
         <hovered>

--- a/Models/Interior/Panel/c172sp-panel/c172sp.xml
+++ b/Models/Interior/Panel/c172sp-panel/c172sp.xml
@@ -3395,7 +3395,6 @@
             <binding>
                 <command>nasal</command>
                 <script>
-                    #kap140.altButton();
                     c172p.click("kap140");
                 </script>
             </binding>
@@ -3993,7 +3992,6 @@
             <binding>
                 <command>nasal</command>
                 <script>
-                    #kap140.altButton();
                     c172p.click("kap140");
                 </script>
             </binding>
@@ -4047,7 +4045,6 @@
             <binding>
                 <command>nasal</command>
                 <script>
-                    #kap140.altButton();
                     c172p.click("kap140");
                 </script>
             </binding>

--- a/c172p-fg1000-gfc-set.xml
+++ b/c172p-fg1000-gfc-set.xml
@@ -119,19 +119,6 @@ model, instrument panel, and external 3D model.
             <play-btn type="bool">false</play-btn>
             <coplt-btn type="bool">false</coplt-btn>
         </audio-panel>
-        <comm>
-            <power-btn type="double">0</power-btn>
-            <volume type="double">0</volume>
-        </comm>
-        <marker-beacon>
-            <audio-btn type="double">0</audio-btn>
-        </marker-beacon>
-        <dme>
-            <ident type="double">0</ident>
-        </dme>
-        <adf>
-            <ident-audible type="double">0</ident-audible>
-        </adf>
         <FG1000>
             <Lightmap type="double">0</Lightmap>
         </FG1000>

--- a/c172p-fg1000-kap-set.xml
+++ b/c172p-fg1000-kap-set.xml
@@ -254,19 +254,6 @@ model, instrument panel, and external 3D model.
             <play-btn type="bool">false</play-btn>
             <coplt-btn type="bool">false</coplt-btn>
         </audio-panel>
-        <comm>
-            <power-btn type="double">0</power-btn>
-            <volume type="double">0</volume>
-        </comm>
-        <marker-beacon>
-            <audio-btn type="double">0</audio-btn>
-        </marker-beacon>
-        <dme>
-            <ident type="double">0</ident>
-        </dme>
-        <adf>
-            <ident-audible type="double">0</ident-audible>
-        </adf>
         <FG1000>
             <Lightmap type="double">0</Lightmap>
         </FG1000>

--- a/c172p-main.xml
+++ b/c172p-main.xml
@@ -751,6 +751,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         </adf>
         <comm n="0">
             <power-btn type="bool">1</power-btn>
+            <volume type="double">0</volume>
             <frequencies>
                 <dial-khz type="int">0</dial-khz>
                 <dial-mhz type="int">0</dial-mhz>
@@ -760,6 +761,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         </comm>
         <comm n="1">
             <power-btn type="bool">1</power-btn>
+            <volume type="double">0</volume>
             <frequencies>
                 <dial-khz type="int">0</dial-khz>
                 <dial-mhz type="int">0</dial-mhz>
@@ -783,6 +785,15 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             </frequencies>
             <ident-audible type="bool">false</ident-audible>
         </nav>
+        <marker-beacon>
+            <audio-btn type="double">0</audio-btn>
+        </marker-beacon>
+        <dme>
+            <ident type="double">0</ident>
+        </dme>
+        <adf>
+            <ident-audible type="double">0</ident-audible>
+        </adf>
         <magnetic-compass>
             <pitch-offset-deg type="double">-2.7</pitch-offset-deg>
         </magnetic-compass>


### PR DESCRIPTION
Fixes #1422 

@dany93 this is a fix for a couple issue on the fg1000 variants for nav and adf. The nav1 and nav2 radios had the wrong properties applied and a typo. It was causing the nav1 audio button on the audio panel to shut off the nav1 radio. The nav2 audio button also was incorrectly configured. The adf audio switch on the audio panel was also mis-configured. A couple properties initialized in the fg1000 variants were moved to the common or main file as they are used in all variants.

Without going into details I verified the following on the fg1000...
ADF audio works,
ADF radio sets ADF direction logic on the fg1000 PFD
NAV1 and NAV1 audio works and the audio panel NAV1 and NAV2 buttons no longer affect the fg1000 PFD NAV 1 and NAV2 logic adversely.

I'm confident this can be merged after a quick check by someone other than me.