### PR TITLE
Track engine hours per engine

### DIFF
--- a/Nasal/engine.nas
+++ b/Nasal/engine.nas
@@ -37,8 +37,18 @@ var update_hobbs_meter = func {
     # This uses minutes, for testing
     #hobbs = hobbs / 60.0;
     # in hours
-    hobbs = (hobbs_160hp + hobbs_180hp) / 3600.0;
+    #hobbs = (hobbs_160hp + hobbs_180hp) / 3600.0;
     # tenths of hour
+
+    var hobbs = 0;
+    var current_engine = getprop("controls/engines/active-engine");
+    if (current_engine == 0) {
+        hobbs = hobbs_160hp / 3600.0;
+    } else
+    if (current_engine == 1) {
+        hobbs = hobbs_180hp / 3600.0;
+    }
+
     setprop("/instrumentation/hobbs-meter/digits0", math.mod(int(hobbs * 10), 10));
     # rest of digits
     setprop("/instrumentation/hobbs-meter/digits1", math.mod(int(hobbs), 10));
@@ -49,6 +59,7 @@ var update_hobbs_meter = func {
 
 setlistener("/sim/time/hobbs/engine[0]", update_hobbs_meter, 1, 0);
 setlistener("/sim/time/hobbs/engine[1]", update_hobbs_meter, 1, 0);
+setlistener("/controls/engines/active-engine", update_hobbs_meter, 1, 0);
 
 # ========== primer stuff ======================
 

--- a/Systems/instruments.xml
+++ b/Systems/instruments.xml
@@ -186,25 +186,6 @@
         </output>
     </filter>
 
-    <filter>
-        <name>Engine Total Hobbs Hours</name>
-        <type>gain</type>
-        <input>
-            <expression>
-                <div>
-                    <sum>
-                        <property>/sim/time/hobbs/engine[0]</property>
-                        <property>/sim/time/hobbs/engine[1]</property>
-                    </sum>
-                    <value>3600.0</value>
-                </div>
-            </expression>
-        </input>
-        <output>
-            <property>/instrumentation/clock/hobbs-meter-hours</property>
-        </output>
-    </filter>
-
     <logic>
         <name>Comm 0 Serviceable</name>
         <input>


### PR DESCRIPTION
Fixes #1424

@dany93 please test.

The only other thing I would like to verify is if we can delete the unused filter in Systems\instruments.xml. Starting at line 189.
~~~
<filter>
        <name>Engine Total Hobbs Hours</name>
        <type>gain</type>
        <input>
            <expression>
                <div>
                    <sum>
                        <property>/sim/time/hobbs/engine[0]</property>
                        <property>/sim/time/hobbs/engine[1]</property>
                    </sum>
                    <value>3600.0</value>
                </div>
            </expression>
        </input>
        <output>
            <property>/instrumentation/clock/hobbs-meter-hours</property>
        </output>
    </filter>
~~~
If is is indeed not being used anywhere I want to delete it before merging.

@wkitty42 maybe you can help verify it is not being used anywhere?
