### PR TITLE
Save restore system bug fix

### DIFF
--- a/Systems/c172p-ground-effects.xml
+++ b/Systems/c172p-ground-effects.xml
@@ -1942,79 +1942,69 @@
             <input>/sim/model/c172p/tiedowns/left/length</input>
             <input>-/sim/model/c172p/tiedowns/left/ref-length</input>
         </summer>
-
+        <fcs_function name="fcs/tiedown-left-magnitude">
+            <function>
+                <product>
+                    <property>/sim/model/c172p/securing/tiedownL-visible</property>
+                    <table>
+                        <independentVar>fcs/tiedown-left-mag-error</independentVar>
+                        <tableData>
+                           -1.0   -50.0
+                           -0.1     0.0
+                            0.0     0.0
+                            0.1     0.0
+                            1.0   7000.0
+                        </tableData>
+                    </table>
+                </product>
+            </function>
+            <output>external_reactions/tiedown-left/magnitude</output>
+        </fcs_function>
         <summer name="fcs/tiedown-right-mag-error">
             <input>/sim/model/c172p/tiedowns/right/length</input>
             <input>-/sim/model/c172p/tiedowns/right/ref-length</input>
         </summer>
-
+        <fcs_function name="fcs/tiedown-right-magnitude">
+            <function>
+                <product>
+                    <property>/sim/model/c172p/securing/tiedownR-visible</property>
+                    <table>
+                        <independentVar>fcs/tiedown-right-mag-error</independentVar>
+                        <tableData>
+                           -1.0   -50.0
+                           -0.1     0.0
+                            0.0     0.0
+                            0.1     0.0
+                            1.0   7000.0
+                        </tableData>
+                    </table>
+                </product>
+            </function>
+            <output>external_reactions/tiedown-right/magnitude</output>
+        </fcs_function>
         <summer name="fcs/tiedown-tail-mag-error">
             <input>/sim/model/c172p/tiedowns/tail/length</input>
             <input>-/sim/model/c172p/tiedowns/tail/ref-length</input>
         </summer>
 
-        <pid name="fcs/tiedown-left-magnitude-pid">
-            <input>fcs/tiedown-left-mag-error</input>
-            <kp>7000.0</kp>
-            <ki>0.0</ki>
-            <kd>500.0</kd>
-            <clipto>
-                <min>-50</min>
-                <max>1000</max>
-            </clipto>
-        </pid>
-
-        <pid name="fcs/tiedown-right-magnitude-pid">
-            <input>fcs/tiedown-right-mag-error</input>
-            <kp>7000.0</kp>
-            <ki>0.0</ki>
-            <kd>500.0</kd>
-            <clipto>
-                <min>-50</min>
-                <max>1000</max>
-            </clipto>
-        </pid>
-
-        <pid name="fcs/tiedown-tail-magnitude-pid">
-            <input>fcs/tiedown-tail-mag-error</input>
-            <kp>7000.0</kp>
-            <ki>0.0</ki>
-            <kd>500.0</kd>
-            <clipto>
-                <min>-50</min>
-                <max>1000</max>
-            </clipto>
-        </pid>
-
-        <switch name="fcs/tiedown-left-magnitude">
-            <output>external_reactions/tiedown-left/magnitude</output>
-            <default value="0"/>
-
-            <test logic="AND" value="fcs/tiedown-left-magnitude-pid">
-                /sim/model/c172p/securing/tiedownL-visible EQ 1
-                /fdm/jsbsim/damage/repairing EQ 0
-            </test>
-        </switch>
-
-        <switch name="fcs/tiedown-right-magnitude">
-            <output>external_reactions/tiedown-right/magnitude</output>
-            <default value="0"/>
-
-            <test logic="AND" value="fcs/tiedown-right-magnitude-pid">
-                /sim/model/c172p/securing/tiedownR-visible EQ 1
-                /fdm/jsbsim/damage/repairing EQ 0
-            </test>
-        </switch>
-
-        <switch name="fcs/tiedown-tail-magnitude">
+        <fcs_function name="fcs/tiedown-tail-magnitude">
+            <function>
+                <product>
+                    <property>/sim/model/c172p/securing/tiedownT-visible</property>
+                    <table>
+                        <independentVar>fcs/tiedown-tail-mag-error</independentVar>
+                        <tableData>
+                           -1.0   -50.0
+                           -0.1     0.0
+                            0.0     0.0
+                            0.1     0.0
+                            1.0   7000.0
+                        </tableData>
+                    </table>
+                </product>
+            </function>
             <output>external_reactions/tiedown-tail/magnitude</output>
-            <default value="0"/>
-
-            <test logic="AND" value="fcs/tiedown-tail-magnitude-pid">
-                /sim/model/c172p/securing/tiedownT-visible EQ 1
-                /fdm/jsbsim/damage/repairing EQ 0
-            </test>
-        </switch>
+        </fcs_function>
 
     </channel>
 

--- a/Systems/ground-effects.xml
+++ b/Systems/ground-effects.xml
@@ -479,7 +479,7 @@ Under the GPL. Used by shadows under ALS -->
     <!-- Securing aircraft                                                  -->
     <!-- ================================================================== -->
 
-	<filter>
+    <filter>
         <name>Controls Parking Brake Lever</name>
         <type>noise-spike</type>
         <max-rate-of-change>2.5</max-rate-of-change>
@@ -491,13 +491,13 @@ Under the GPL. Used by shadows under ALS -->
             </condition>
         </enable>
         <input>
-			<condition>
-				<property>/controls/gear/brake-parking</property>
+            <condition>
+                <property>/controls/gear/brake-parking</property>
             </condition>
-			<value>1.0</value>
+            <value>1.0</value>
         </input>
-		<input>
-			<value>0.0</value>
+        <input>
+            <value>0.0</value>
         </input>
         <output>
             <property>/sim/model/c172p/cockpit/parking-lever</property>
@@ -683,6 +683,71 @@ Under the GPL. Used by shadows under ALS -->
             <property>/sim/model/c172p/securing/tiedownT-addable</property>
         </output>
     </logic>
+
+    <filter>
+        <name>Tail Tiedowns ripoff: left</name>
+        <type>gain</type>
+        <enable>
+            <condition>
+                <or>
+                    <greater-than>
+                        <property>/position/altitude-agl-ft</property>
+                        <value>10</value>
+                    </greater-than>
+                    <greater-than>
+                        <property>/fdm/jsbsim/fcs/tiedown-left-magnitude</property>
+                        <value>1500</value>
+                    </greater-than>
+                </or>
+            </condition>
+        </enable>
+        <input> <value>0</value> </input>
+        <output> <property>/sim/model/c172p/securing/tiedownL-visible</property> </output>
+    </filter>
+    <filter>
+        <name>Tail Tiedowns ripoff: rigth</name>
+        <type>gain</type>
+        <enable>
+            <condition>
+                <or>
+                    <greater-than>
+                        <property>/position/altitude-agl-ft</property>
+                        <value>10</value>
+                    </greater-than>
+                    <greater-than>
+                        <property>/fdm/jsbsim/fcs/tiedown-rigth-magnitude</property>
+                        <value>1500</value>
+                    </greater-than>
+                </or>
+            </condition>
+        </enable>
+        <input> <value>0</value> </input>
+        <output>
+            <property>/sim/model/c172p/securing/tiedownR-visible</property>
+        </output>
+    </filter>
+    <filter>
+        <name>Tail Tiedowns ripoff: tail</name>
+        <type>gain</type>
+        <enable>
+            <condition>
+                <or>
+                    <greater-than>
+                        <property>/position/altitude-agl-ft</property>
+                        <value>10</value>
+                    </greater-than>
+                    <greater-than>
+                        <property>/fdm/jsbsim/fcs/tiedown-tail-magnitude</property>
+                        <value>1500</value>
+                    </greater-than>
+                </or>
+            </condition>
+        </enable>
+        <input> <value>0</value> </input>
+        <output>
+            <property>/sim/model/c172p/securing/tiedownT-visible</property>
+        </output>
+    </filter>
 
     <!-- ================================================================== -->
     <!-- Lighting  -->

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -241,10 +241,10 @@
                         <not>
                             <property>/engines/active-engine/running</property>
                         </not>
-                        <equals>
+                        <less-than>
                             <property>/engines/active-engine/rpm</property>
-                            <value>0</value>
-                        </equals>
+                            <value>1</value>
+                        </less-than>
                     </and>
                 </enable>
                 <binding>


### PR DESCRIPTION
@dany93 

I think there is room for improvement down the road. You can get some strange restore results when restoring across fg1000 vs non-glass variant choices. I'm not ready to tackle that yet.

This work is only to repair the basic functionality. It was broke because of some unaccounted for properties that were introduced when the fg1000 variant came online. I tested for, no crashes, no nasal errors and that it basically works.

This is ready to merge. I plan to cherry pick this back to the new 2020.4.1 release as a bug fix.