### PR TITLE
Tutorial fixes

### DIFF
--- a/Tutorials/preflight.xml
+++ b/Tutorials/preflight.xml
@@ -347,13 +347,13 @@ This tutorial will guide you through the Preflight inspection
             <message>Set the parking brake.</message>
             <condition>
                 <not>
-                    <property>sim/model/c172p/brake-parking</property>
+                    <property>/controls/gear/brake-parking</property>
                 </not>
             </condition>
         </error>
         <exit>
             <condition>
-                <property>sim/model/c172p/brake-parking</property>
+                <property>/controls/gear/brake-parking</property>
             </condition>
         </exit>
     </step>

--- a/Tutorials/securing.xml
+++ b/Tutorials/securing.xml
@@ -291,13 +291,13 @@ This tutorial will take you through that process.
             <message>You need to set the parking brake or the aircraft may roll away!</message>
             <condition>
                 <not>
-                    <property>sim/model/c172p/brake-parking</property>
+                    <property>/controls/gear/brake-parking</property>
                 </not>
             </condition>
         </error>
         <exit>
             <condition>
-                <property>sim/model/c172p/brake-parking</property>
+                <property>/controls/gear/brake-parking</property>
             </condition>
         </exit>
     </step>

--- a/Tutorials/startup.xml
+++ b/Tutorials/startup.xml
@@ -246,13 +246,13 @@ This tutorial will take you through starting the Cessna 172p.
             <message>Set the parking brake.</message>
             <condition>
                 <not>
-                    <property>sim/model/c172p/brake-parking</property>
+                    <property>/controls/gear/brake-parking</property>
                 </not>
             </condition>
         </error>
         <exit>
             <condition>
-                <property>sim/model/c172p/brake-parking</property>
+                <property>/controls/gear/brake-parking</property>
             </condition>
         </exit>
     </step>

--- a/Tutorials/startup.xml
+++ b/Tutorials/startup.xml
@@ -407,7 +407,7 @@ This tutorial will take you through starting the Cessna 172p.
         <exit>
             <condition>
                 <and>
-                    <property>/controls/circuit-breakers/aircond</property>
+                    <!--property>/controls/circuit-breakers/aircond</property-->
                     <property>/controls/circuit-breakers/autopilot</property>
                     <property>/controls/circuit-breakers/bcnlt</property>
                     <property>/controls/circuit-breakers/flaps</property>


### PR DESCRIPTION
A couple of tutorial fixes. They weren't getting past the parking brake being set due to stale reference to /sim/model/c172p/brake-parking, nor the circuit breakers due to a stale reference to the aircond circuit breaker.