### PR TITLE
Magnetic Compass enhancements

### DIFF
--- a/Models/Interior/Panel/Instruments/mag-compass/mag-compass-fg1000.xml
+++ b/Models/Interior/Panel/Instruments/mag-compass/mag-compass-fg1000.xml
@@ -76,6 +76,38 @@
     <animation>
         <type>rotate</type>
         <object-name>Ring</object-name>
+        <property>instrumentation/magnetic-compass/roll-deg-final</property>
+        <factor>0.5</factor>
+        <axis>
+            <x> 1.0 </x>
+            <y> 0.0 </y>
+            <z> 0.0 </z>
+        </axis>
+        <center>
+            <x-m>-0.3769</x-m>
+            <y-m>0.0000</y-m>
+            <z-m>0.2405</z-m>
+        </center>
+    </animation>
+    <animation>
+        <type>rotate</type>
+        <object-name>Ring</object-name>
+        <property>instrumentation/magnetic-compass/pitch-deg-final</property>
+        <factor>0.5</factor>
+        <axis>
+            <x>  0.0 </x>
+            <y> -1.0 </y>
+            <z>  0.0 </z>
+        </axis>
+        <center>
+            <x-m>-0.3769</x-m>
+            <y-m>0.0000</y-m>
+            <z-m>0.2405</z-m>
+        </center>
+    </animation>
+    <animation>
+        <type>rotate</type>
+        <object-name>Ring</object-name>
         <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
         <factor>-1</factor>
         <axis>

--- a/Models/Interior/Panel/Instruments/mag-compass/mag-compass-fg1000.xml
+++ b/Models/Interior/Panel/Instruments/mag-compass/mag-compass-fg1000.xml
@@ -76,7 +76,7 @@
     <animation>
         <type>rotate</type>
         <object-name>Ring</object-name>
-        <property>instrumentation/magnetic-compass/indicated-heading-deg</property>
+        <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
         <factor>-1</factor>
         <axis>
             <x1-m>-0.36466</x1-m>
@@ -96,7 +96,7 @@
                 <command>set-tooltip</command>
                 <tooltip-id>magnetcompass</tooltip-id>
                 <label>Magnetic heading: %3d</label>
-                <property>instrumentation/magnetic-compass/indicated-heading-deg</property>
+                <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
                 <mapping>heading</mapping>
             </binding>
         </hovered>

--- a/Models/Interior/Panel/Instruments/mag-compass/mag-compass-float-fg1000.xml
+++ b/Models/Interior/Panel/Instruments/mag-compass/mag-compass-float-fg1000.xml
@@ -64,6 +64,28 @@
     <animation>
         <type>rotate</type>
         <object-name>Ring</object-name>
+        <property>instrumentation/magnetic-compass/roll-deg-final</property>
+        <factor>0.5</factor>
+        <axis>
+            <x> 1.0 </x>
+            <y> 0.0 </y>
+            <z> 0.0 </z>
+        </axis>
+    </animation>
+    <animation>
+        <type>rotate</type>
+        <object-name>Ring</object-name>
+        <property>instrumentation/magnetic-compass/pitch-deg-final</property>
+        <factor>0.5</factor>
+        <axis>
+            <x>  0.0 </x>
+            <y> -1.0 </y>
+            <z>  0.0 </z>
+        </axis>
+    </animation>
+    <animation>
+        <type>rotate</type>
+        <object-name>Ring</object-name>
         <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
         <factor>-1</factor>
         <axis>

--- a/Models/Interior/Panel/Instruments/mag-compass/mag-compass-float-fg1000.xml
+++ b/Models/Interior/Panel/Instruments/mag-compass/mag-compass-float-fg1000.xml
@@ -64,7 +64,7 @@
     <animation>
         <type>rotate</type>
         <object-name>Ring</object-name>
-        <property>instrumentation/magnetic-compass/indicated-heading-deg</property>
+        <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
         <factor>-1</factor>
         <axis>
             <x1-m>-0.33052</x1-m>
@@ -84,7 +84,7 @@
                 <command>set-tooltip</command>
                 <tooltip-id>magnetcompass</tooltip-id>
                 <label>Magnetic heading: %3d</label>
-                <property>instrumentation/magnetic-compass/indicated-heading-deg</property>
+                <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
                 <mapping>heading</mapping>
             </binding>
         </hovered>

--- a/Models/Interior/Panel/Instruments/mag-compass/mag-compass-float.xml
+++ b/Models/Interior/Panel/Instruments/mag-compass/mag-compass-float.xml
@@ -76,6 +76,28 @@
     <animation>
         <type>rotate</type>
         <object-name>Ring</object-name>
+        <property>instrumentation/magnetic-compass/roll-deg-final</property>
+        <factor>0.5</factor>
+        <axis>
+            <x> 1.0 </x>
+            <y> 0.0 </y>
+            <z> 0.0 </z>
+        </axis>
+    </animation>
+    <animation>
+        <type>rotate</type>
+        <object-name>Ring</object-name>
+        <property>instrumentation/magnetic-compass/pitch-deg-final</property>
+        <factor>0.5</factor>
+        <axis>
+            <x>  0.0 </x>
+            <y> -1.0 </y>
+            <z>  0.0 </z>
+        </axis>
+    </animation>
+    <animation>
+        <type>rotate</type>
+        <object-name>Ring</object-name>
         <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
         <factor>-1</factor>
         <axis>

--- a/Models/Interior/Panel/Instruments/mag-compass/mag-compass-float.xml
+++ b/Models/Interior/Panel/Instruments/mag-compass/mag-compass-float.xml
@@ -76,7 +76,7 @@
     <animation>
         <type>rotate</type>
         <object-name>Ring</object-name>
-        <property>instrumentation/magnetic-compass/indicated-heading-deg</property>
+        <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
         <factor>-1</factor>
         <axis>
             <x1-m>-0.33052</x1-m>
@@ -96,7 +96,7 @@
                 <command>set-tooltip</command>
                 <tooltip-id>magnetcompass</tooltip-id>
                 <label>Magnetic heading: %3d</label>
-                <property>instrumentation/magnetic-compass/indicated-heading-deg</property>
+                <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
                 <mapping>heading</mapping>
             </binding>
         </hovered>

--- a/Models/Interior/Panel/Instruments/mag-compass/mag-compass.xml
+++ b/Models/Interior/Panel/Instruments/mag-compass/mag-compass.xml
@@ -76,6 +76,38 @@
     <animation>
         <type>rotate</type>
         <object-name>Ring</object-name>
+        <property>instrumentation/magnetic-compass/roll-deg-final</property>
+        <factor>0.5</factor>
+        <axis>
+            <x> 1.0 </x>
+            <y> 0.0 </y>
+            <z> 0.0 </z>
+        </axis>
+        <center>
+            <x-m>-0.3769</x-m>
+            <y-m>0.0000</y-m>
+            <z-m>0.2405</z-m>
+        </center>
+    </animation>
+    <animation>
+        <type>rotate</type>
+        <object-name>Ring</object-name>
+        <property>instrumentation/magnetic-compass/pitch-deg-final</property>
+        <factor>0.5</factor>
+        <axis>
+            <x>  0.0 </x>
+            <y> -1.0 </y>
+            <z>  0.0 </z>
+        </axis>
+        <center>
+            <x-m>-0.3769</x-m>
+            <y-m>0.0000</y-m>
+            <z-m>0.2405</z-m>
+        </center>
+    </animation>
+    <animation>
+        <type>rotate</type>
+        <object-name>Ring</object-name>
         <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
         <factor>-1</factor>
         <axis>

--- a/Models/Interior/Panel/Instruments/mag-compass/mag-compass.xml
+++ b/Models/Interior/Panel/Instruments/mag-compass/mag-compass.xml
@@ -76,7 +76,7 @@
     <animation>
         <type>rotate</type>
         <object-name>Ring</object-name>
-        <property>instrumentation/magnetic-compass/indicated-heading-deg</property>
+        <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
         <factor>-1</factor>
         <axis>
             <x1-m>-0.36466</x1-m>
@@ -96,7 +96,7 @@
                 <command>set-tooltip</command>
                 <tooltip-id>magnetcompass</tooltip-id>
                 <label>Magnetic heading: %3d</label>
-                <property>instrumentation/magnetic-compass/indicated-heading-deg</property>
+                <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
                 <mapping>heading</mapping>
             </binding>
         </hovered>

--- a/Nasal/electrical-fg1000.nas
+++ b/Nasal/electrical-fg1000.nas
@@ -713,9 +713,11 @@ var avionics_bus_2 = func() {
     # Audio Panel 1 Power
     if ( getprop("/controls/circuit-breakers/audio") ) {
         setprop("/systems/electrical/outputs/audio-panel[0]", bus_volts);
+        setprop("/instrumentation/audio-panel[0]/operable", 1);
         load += 5 * bus_volts;
     } else {
         setprop("/systems/electrical/outputs/audio-panel[0]", 0.0);
+        setprop("/instrumentation/audio-panel[0]/operable", 0);
     }
 
     # Autopilot Power

--- a/Nasal/electrical.nas
+++ b/Nasal/electrical.nas
@@ -504,9 +504,11 @@ var avionics_bus_1 = func() {
     # Audio Panel 1 Power
     if ( getprop("/controls/circuit-breakers/radio1") ) {
       setprop("/systems/electrical/outputs/audio-panel[0]", bus_volts);
+      setprop("/instrumentation/audio-panel[0]/operable", 1);
       load += 5 * bus_volts;
     } else {
       setprop("/systems/electrical/outputs/audio-panel[0]", 0.0);
+      setprop("/instrumentation/audio-panel[0]/operable", 0);
     }
 
     # Com and Nav 1 Power

--- a/Systems/instrumentation.xml
+++ b/Systems/instrumentation.xml
@@ -91,60 +91,7 @@ file, these values will be used (they are hardcoded).
     <magnetic-compass>
         <name>magnetic-compass</name>
         <number>0</number>
-        <!-- use either deviation property or deviation table for compass deviation -->
-        <!--deviation>/instrumentation/magnetic-compass/deviation-deg</deviation-->
-        <deviation>
-            <table>
-                <entry>
-                    <ind>0</ind>
-                    <dep>0</dep>
-                </entry>
-                <entry>
-                    <ind>30</ind>
-                    <dep>2</dep>
-                </entry>
-                <entry>
-                    <ind>60</ind>
-                    <dep>3</dep>
-                </entry>
-                <entry>
-                    <ind>90</ind>
-                    <dep>4</dep>
-                </entry>
-                <entry>
-                    <ind>120</ind>
-                    <dep>3</dep>
-                </entry>
-                <entry>
-                    <ind>150</ind>
-                    <dep>2</dep>
-                </entry>
-                <entry>
-                    <ind>180</ind>
-                    <dep>0</dep>
-                </entry>
-                <entry>
-                    <ind>210</ind>
-                    <dep>-2</dep>
-                </entry>
-                <entry>
-                    <ind>240</ind>
-                    <dep>-3</dep>
-                </entry>
-                <entry>
-                    <ind>270</ind>
-                    <dep>-4</dep>
-                </entry>
-                <entry>
-                    <ind>300</ind>
-                    <dep>-3</dep>
-                </entry>
-                <entry>
-                    <ind>330</ind>
-                    <dep>-2</dep>
-                </entry>
-            </table>
-        </deviation>
+        <deviation>/instrumentation/magnetic-compass/deviation-deg</deviation>
     </magnetic-compass>
 
     <comm-radio>

--- a/Systems/instruments.xml
+++ b/Systems/instruments.xml
@@ -594,5 +594,167 @@
            <property>/sim/model/lightmap/instruments/factor</property>
         </output>
     </filter>
-
+    
+    
+    <filter>
+        <name>Magnetic compass electrical influence</name>
+        <type>gain</type>
+        <input>
+          <expression>
+            <div>
+              <sum>
+                <!-- using the value in the product we can weight the current and distance of the influence -->
+                <product><value>10</value><property>/instrumentation/audio-panel/operable</property></product> <!-- todo: define a nasal switch for that in nasal code -->
+                <product><value>10</value><property>/instrumentation/dme/operable</property></product>
+                <product><value>25</value><property>/instrumentation/comm[0]/operable/</property></product>
+                <product><value>10</value><property>/instrumentation/nav[0]/operable/</property></product>
+                <product><value>25</value><property>/instrumentation/comm[1]/operable</property></product>
+                <product><value>10</value><property>/instrumentation/nav[1]/operable/</property></product>
+                <product><value>10</value><property>/instrumentation/adf/operable</property></product>
+              </sum>
+              <value>100</value> <!-- total of weighting -->
+            </div>
+          </expression>
+        </input>
+        <output>
+            <property>/instrumentation/magnetic-compass/electrical-influence-norm</property>
+        </output>
+    </filter>
+    <filter>
+        <name>Magnetic compass deviation</name>
+        <!-- To debug this, set /orientation/heading-deg to the desired value + declination (so heading-magnetic-deg shows the desired target value).
+             The compass should then read the corrected value from the table below (and the corresponding card in the cockpit).
+        -->
+        <type>gain</type>
+        <input>
+            <expression>
+              <sum>
+                <!-- With avionics ON -->
+                <product>
+                  <table>
+                    <property>/orientation/heading-magnetic-deg</property>
+                    <entry><ind>   0 </ind><dep>  0 </dep></entry>
+                    <entry><ind>  30 </ind><dep> -2 </dep></entry>
+                    <entry><ind>  60 </ind><dep> -3 </dep></entry>
+                    <entry><ind>  90 </ind><dep> -4 </dep></entry>
+                    <entry><ind> 120 </ind><dep> -3 </dep></entry>
+                    <entry><ind> 150 </ind><dep> -2 </dep></entry>
+                    <entry><ind> 180 </ind><dep>  0 </dep></entry>
+                    <entry><ind> 210 </ind><dep>  2 </dep></entry>
+                    <entry><ind> 240 </ind><dep>  3 </dep></entry>
+                    <entry><ind> 270 </ind><dep>  4 </dep></entry>
+                    <entry><ind> 300 </ind><dep>  3 </dep></entry>
+                    <entry><ind> 330 </ind><dep>  2 </dep></entry>
+                    <entry><ind> 360 </ind><dep>  0 </dep></entry> <!-- same as 0! -->
+                  </table>
+                  <property>/instrumentation/magnetic-compass/electrical-influence-norm</property>
+                </product>
+                  
+                <!-- With avionics OFF -->
+                <product>
+                  <table>
+                    <property>/orientation/heading-magnetic-deg</property>
+                    <entry><ind>   0 </ind><dep> -1 </dep></entry>
+                    <entry><ind>  30 </ind><dep> -3 </dep></entry>
+                    <entry><ind>  60 </ind><dep> -5 </dep></entry>
+                    <entry><ind>  90 </ind><dep> -7 </dep></entry>
+                    <entry><ind> 120 </ind><dep> -5 </dep></entry>
+                    <entry><ind> 150 </ind><dep> -3 </dep></entry>
+                    <entry><ind> 180 </ind><dep> -1 </dep></entry>
+                    <entry><ind> 210 </ind><dep>  3 </dep></entry>
+                    <entry><ind> 240 </ind><dep>  5 </dep></entry>
+                    <entry><ind> 270 </ind><dep>  7 </dep></entry>
+                    <entry><ind> 300 </ind><dep>  5 </dep></entry>
+                    <entry><ind> 330 </ind><dep>  3 </dep></entry>
+                    <entry><ind> 360 </ind><dep> -1 </dep></entry> <!-- same as 0! -->
+                  </table>
+                  <difference>
+                    <value>1</value>
+                    <property>/instrumentation/magnetic-compass/electrical-influence-norm</property>
+                  </difference>
+                </product>
+              </sum>
+            </expression>
+        </input>
+        <output>
+            <property>/instrumentation/magnetic-compass/deviation-deg</property>
+        </output>
+    </filter>
+    <filter>
+        <name>Magnetic compass pivot mounting</name>
+        <type>exponential</type>
+        <filter-time>5.0</filter-time>
+        <input>
+          <expression>
+            <product>
+              <property>/orientation/pitch-deg</property>
+              <value>-1</value>
+            </product>
+          </expression>
+        </input>
+        <output>
+            <property>/instrumentation/magnetic-compass/pitch-offset-deg</property>
+        </output>
+        <min> <property>instrumentation/magnetic-compass/pitch-limit-down</property> </min>
+        <max> <property>instrumentation/magnetic-compass/pitch-limit-up</property> </max>
+    </filter>
+    <filter>
+        <name>Magnetic compass stuck</name>
+        <type>gain</type>
+        <input>
+            <condition>
+              <or>
+                <less-than>
+                  <property>/orientation/pitch-deg</property>
+                  <property>instrumentation/magnetic-compass/pitch-limit-down</property>
+                </less-than>
+                <greater-than>
+                  <property>/orientation/pitch-deg</property>
+                  <property>instrumentation/magnetic-compass/pitch-limit-up</property>
+                </greater-than>
+              </or>
+            </condition>
+            <value>1</value>
+        </input>
+        <input>
+            <value>0</value>
+        </input>
+        <output>
+            <property>instrumentation/magnetic-compass/stuck</property>
+        </output>
+    </filter>
+    <filter>
+        <name>Magnetic compass rotation reponsiveness</name>
+        <type>exponential</type>
+        <filter-time>2.0</filter-time>
+        <input>
+            <condition>
+                <property>instrumentation/magnetic-compass/stuck</property>
+            </condition>
+            <value>2</value> <!-- slow to respond after getting stuck for a longer time -->
+        </input>
+        <input>
+            <value>0.0001</value> <!-- just hand trough the original value -->
+        </input>
+        <output>
+            <property>instrumentation/magnetic-compass/responsiveness</property>
+        </output>
+    </filter>
+    <filter>
+        <name>Magnetic compass rotation</name>
+        <type>exponential</type>
+        <filter-time><property>instrumentation/magnetic-compass/responsiveness</property></filter-time>
+        <input>
+            <condition>
+                <property>instrumentation/magnetic-compass/stuck</property>
+            </condition>
+            <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
+        </input>
+        <input>
+            <property>instrumentation/magnetic-compass/indicated-heading-deg</property>
+        </input>
+        <output>
+            <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
+        </output>
+    </filter>
 </PropertyList>

--- a/Systems/instruments.xml
+++ b/Systems/instruments.xml
@@ -596,6 +596,7 @@
     </filter>
     
     
+    <!-- Magnetic compass -->
     <filter>
         <name>Magnetic compass electrical influence</name>
         <type>gain</type>
@@ -712,6 +713,14 @@
                   <property>/orientation/pitch-deg</property>
                   <property>instrumentation/magnetic-compass/pitch-limit-up</property>
                 </greater-than>
+                <less-than>
+                  <property>/orientation/roll-deg</property>
+                  <property>instrumentation/magnetic-compass/roll-limit-left</property>
+                </less-than>
+                <greater-than>
+                  <property>/orientation/roll-deg</property>
+                  <property>instrumentation/magnetic-compass/roll-limit-right</property>
+                </greater-than>
               </or>
             </condition>
             <value>1</value>
@@ -737,13 +746,13 @@
             <value>0.0001</value> <!-- just hand trough the original value -->
         </input>
         <output>
-            <property>instrumentation/magnetic-compass/responsiveness</property>
+            <property>instrumentation/magnetic-compass/rotation-responsiveness</property>
         </output>
     </filter>
     <filter>
         <name>Magnetic compass rotation</name>
         <type>exponential</type>
-        <filter-time><property>instrumentation/magnetic-compass/responsiveness</property></filter-time>
+        <filter-time><property>instrumentation/magnetic-compass/rotation-responsiveness</property></filter-time>
         <input>
             <condition>
                 <property>instrumentation/magnetic-compass/stuck</property>
@@ -755,6 +764,40 @@
         </input>
         <output>
             <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
+        </output>
+    </filter>
+    <filter>
+        <name>Magnetic compass pitch</name>
+        <type>exponential</type>
+        <filter-time>0.25</filter-time> <!-- simulate damping fluid -->
+        <input>
+            <condition>
+                <property>instrumentation/magnetic-compass/stuck</property>
+            </condition>
+            <property>instrumentation/magnetic-compass/pitch-deg-final</property>
+        </input>
+        <input>
+            <property>orientation/pitch-deg</property>
+        </input>
+        <output>
+            <property>instrumentation/magnetic-compass/pitch-deg-final</property>
+        </output>
+    </filter>
+    <filter>
+        <name>Magnetic compass roll</name>
+        <type>exponential</type>
+        <filter-time>0.25</filter-time> <!-- simulate damping fluid -->
+        <input>
+            <condition>
+                <property>instrumentation/magnetic-compass/stuck</property>
+            </condition>
+            <property>instrumentation/magnetic-compass/roll-deg-final</property>
+        </input>
+        <input>
+            <property>orientation/roll-deg</property>
+        </input>
+        <output>
+            <property>instrumentation/magnetic-compass/roll-deg-final</property>
         </output>
     </filter>
 </PropertyList>

--- a/c172p-amphibious-set.xml
+++ b/c172p-amphibious-set.xml
@@ -184,6 +184,15 @@ model, instrument panel, and external 3D model.
         <altimeter-kap140-internal>
             <serviceable type="bool">true</serviceable>
         </altimeter-kap140-internal>
+        <magnetic-compass>
+            <!-- Compass will get stuck and have bad readings when exceeding this limits in degrees.
+                no better source found than "in most compasses, the bowl to tilt by approximately 18
+                degrees before it will touch the side of the casing" https://en.wikipedia.org/wiki/Aircraft_compass_turns.
+                From testing this looks enough for normal flight and pre-takeoff-calibration. -->
+            <pitch-limit-up type="float">    9 </pitch-limit-up>
+            <pitch-limit-down type="float"> -9 </pitch-limit-down>
+            <stuck type="bool"> 0 </stuck>
+        </magnetic-compass>
     </instrumentation>
     <fdm>
         <jsbsim>

--- a/c172p-amphibious-set.xml
+++ b/c172p-amphibious-set.xml
@@ -189,8 +189,10 @@ model, instrument panel, and external 3D model.
                 no better source found than "in most compasses, the bowl to tilt by approximately 18
                 degrees before it will touch the side of the casing" https://en.wikipedia.org/wiki/Aircraft_compass_turns.
                 From testing this looks enough for normal flight and pre-takeoff-calibration. -->
-            <pitch-limit-up type="float">    9 </pitch-limit-up>
-            <pitch-limit-down type="float"> -9 </pitch-limit-down>
+            <pitch-limit-up type="float">     9 </pitch-limit-up>
+            <pitch-limit-down type="float">  -9 </pitch-limit-down>
+            <roll-limit-right type="float">  25 </roll-limit-right>
+            <roll-limit-left type="float">  -25 </roll-limit-left>
             <stuck type="bool"> 0 </stuck>
         </magnetic-compass>
     </instrumentation>

--- a/c172p-bush26-set.xml
+++ b/c172p-bush26-set.xml
@@ -186,8 +186,10 @@ model, instrument panel, and external 3D model.
                 no better source found than "in most compasses, the bowl to tilt by approximately 18
                 degrees before it will touch the side of the casing" https://en.wikipedia.org/wiki/Aircraft_compass_turns.
                 From testing this looks enough for normal flight and pre-takeoff-calibration. -->
-            <pitch-limit-up type="float">    9 </pitch-limit-up>
-            <pitch-limit-down type="float"> -9 </pitch-limit-down>
+            <pitch-limit-up type="float">     9 </pitch-limit-up>
+            <pitch-limit-down type="float">  -9 </pitch-limit-down>
+            <roll-limit-right type="float">  25 </roll-limit-right>
+            <roll-limit-left type="float">  -25 </roll-limit-left>
             <stuck type="bool"> 0 </stuck>
         </magnetic-compass>
     </instrumentation>

--- a/c172p-bush26-set.xml
+++ b/c172p-bush26-set.xml
@@ -181,6 +181,15 @@ model, instrument panel, and external 3D model.
         <altimeter-kap140-internal>
             <serviceable type="bool">true</serviceable>
         </altimeter-kap140-internal>
+        <magnetic-compass>
+            <!-- Compass will get stuck and have bad readings when exceeding this limits in degrees.
+                no better source found than "in most compasses, the bowl to tilt by approximately 18
+                degrees before it will touch the side of the casing" https://en.wikipedia.org/wiki/Aircraft_compass_turns.
+                From testing this looks enough for normal flight and pre-takeoff-calibration. -->
+            <pitch-limit-up type="float">    9 </pitch-limit-up>
+            <pitch-limit-down type="float"> -9 </pitch-limit-down>
+            <stuck type="bool"> 0 </stuck>
+        </magnetic-compass>
     </instrumentation>
     <fdm>
         <jsbsim>

--- a/c172p-bush36-set.xml
+++ b/c172p-bush36-set.xml
@@ -180,6 +180,15 @@ model, instrument panel, and external 3D model.
         <altimeter-kap140-internal>
             <serviceable type="bool">true</serviceable>
         </altimeter-kap140-internal>
+        <magnetic-compass>
+            <!-- Compass will get stuck and have bad readings when exceeding this limits in degrees.
+                no better source found than "in most compasses, the bowl to tilt by approximately 18
+                degrees before it will touch the side of the casing" https://en.wikipedia.org/wiki/Aircraft_compass_turns.
+                From testing this looks enough for normal flight and pre-takeoff-calibration. -->
+            <pitch-limit-up type="float">    9 </pitch-limit-up>
+            <pitch-limit-down type="float"> -9 </pitch-limit-down>
+            <stuck type="bool"> 0 </stuck>
+        </magnetic-compass>
     </instrumentation>
     <fdm>
         <jsbsim>

--- a/c172p-bush36-set.xml
+++ b/c172p-bush36-set.xml
@@ -185,8 +185,10 @@ model, instrument panel, and external 3D model.
                 no better source found than "in most compasses, the bowl to tilt by approximately 18
                 degrees before it will touch the side of the casing" https://en.wikipedia.org/wiki/Aircraft_compass_turns.
                 From testing this looks enough for normal flight and pre-takeoff-calibration. -->
-            <pitch-limit-up type="float">    9 </pitch-limit-up>
-            <pitch-limit-down type="float"> -9 </pitch-limit-down>
+            <pitch-limit-up type="float">     9 </pitch-limit-up>
+            <pitch-limit-down type="float">  -9 </pitch-limit-down>
+            <roll-limit-right type="float">  25 </roll-limit-right>
+            <roll-limit-left type="float">  -25 </roll-limit-left>
             <stuck type="bool"> 0 </stuck>
         </magnetic-compass>
     </instrumentation>

--- a/c172p-fg1000-gfc-set.xml
+++ b/c172p-fg1000-gfc-set.xml
@@ -122,6 +122,15 @@ model, instrument panel, and external 3D model.
         <FG1000>
             <Lightmap type="double">0</Lightmap>
         </FG1000>
+        <magnetic-compass>
+            <!-- Compass will get stuck and have bad readings when exceeding this limits in degrees.
+                no better source found than "in most compasses, the bowl to tilt by approximately 18
+                degrees before it will touch the side of the casing" https://en.wikipedia.org/wiki/Aircraft_compass_turns.
+                From testing this looks enough for normal flight and pre-takeoff-calibration. -->
+            <pitch-limit-up type="float">    9 </pitch-limit-up>
+            <pitch-limit-down type="float"> -9 </pitch-limit-down>
+            <stuck type="bool"> 0 </stuck>
+        </magnetic-compass>
     </instrumentation>
     <nasal>
         <electrical>

--- a/c172p-fg1000-gfc-set.xml
+++ b/c172p-fg1000-gfc-set.xml
@@ -127,8 +127,10 @@ model, instrument panel, and external 3D model.
                 no better source found than "in most compasses, the bowl to tilt by approximately 18
                 degrees before it will touch the side of the casing" https://en.wikipedia.org/wiki/Aircraft_compass_turns.
                 From testing this looks enough for normal flight and pre-takeoff-calibration. -->
-            <pitch-limit-up type="float">    9 </pitch-limit-up>
-            <pitch-limit-down type="float"> -9 </pitch-limit-down>
+            <pitch-limit-up type="float">     9 </pitch-limit-up>
+            <pitch-limit-down type="float">  -9 </pitch-limit-down>
+            <roll-limit-right type="float">  25 </roll-limit-right>
+            <roll-limit-left type="float">  -25 </roll-limit-left>
             <stuck type="bool"> 0 </stuck>
         </magnetic-compass>
     </instrumentation>

--- a/c172p-fg1000-kap-set.xml
+++ b/c172p-fg1000-kap-set.xml
@@ -286,8 +286,10 @@ model, instrument panel, and external 3D model.
                 no better source found than "in most compasses, the bowl to tilt by approximately 18
                 degrees before it will touch the side of the casing" https://en.wikipedia.org/wiki/Aircraft_compass_turns.
                 From testing this looks enough for normal flight and pre-takeoff-calibration. -->
-            <pitch-limit-up type="float">    9 </pitch-limit-up>
-            <pitch-limit-down type="float"> -9 </pitch-limit-down>
+            <pitch-limit-up type="float">     9 </pitch-limit-up>
+            <pitch-limit-down type="float">  -9 </pitch-limit-down>
+            <roll-limit-right type="float">  25 </roll-limit-right>
+            <roll-limit-left type="float">  -25 </roll-limit-left>
             <stuck type="bool"> 0 </stuck>
         </magnetic-compass>
     </instrumentation>

--- a/c172p-fg1000-kap-set.xml
+++ b/c172p-fg1000-kap-set.xml
@@ -281,6 +281,15 @@ model, instrument panel, and external 3D model.
         <altimeter-kap140-internal>
             <serviceable type="bool">true</serviceable>
         </altimeter-kap140-internal>
+        <magnetic-compass>
+            <!-- Compass will get stuck and have bad readings when exceeding this limits in degrees.
+                no better source found than "in most compasses, the bowl to tilt by approximately 18
+                degrees before it will touch the side of the casing" https://en.wikipedia.org/wiki/Aircraft_compass_turns.
+                From testing this looks enough for normal flight and pre-takeoff-calibration. -->
+            <pitch-limit-up type="float">    9 </pitch-limit-up>
+            <pitch-limit-down type="float"> -9 </pitch-limit-down>
+            <stuck type="bool"> 0 </stuck>
+        </magnetic-compass>
     </instrumentation>
     <fdm>
         <jsbsim>

--- a/c172p-float-set.xml
+++ b/c172p-float-set.xml
@@ -186,8 +186,10 @@ model, instrument panel, and external 3D model.
                 no better source found than "in most compasses, the bowl to tilt by approximately 18
                 degrees before it will touch the side of the casing" https://en.wikipedia.org/wiki/Aircraft_compass_turns.
                 From testing this looks enough for normal flight and pre-takeoff-calibration. -->
-            <pitch-limit-up type="float">    9 </pitch-limit-up>
-            <pitch-limit-down type="float"> -9 </pitch-limit-down>
+            <pitch-limit-up type="float">     9 </pitch-limit-up>
+            <pitch-limit-down type="float">  -9 </pitch-limit-down>
+            <roll-limit-right type="float">  25 </roll-limit-right>
+            <roll-limit-left type="float">  -25 </roll-limit-left>
             <stuck type="bool"> 0 </stuck>
         </magnetic-compass>
     </instrumentation>

--- a/c172p-float-set.xml
+++ b/c172p-float-set.xml
@@ -181,6 +181,15 @@ model, instrument panel, and external 3D model.
         <altimeter-kap140-internal>
             <serviceable type="bool">true</serviceable>
         </altimeter-kap140-internal>
+        <magnetic-compass>
+            <!-- Compass will get stuck and have bad readings when exceeding this limits in degrees.
+                no better source found than "in most compasses, the bowl to tilt by approximately 18
+                degrees before it will touch the side of the casing" https://en.wikipedia.org/wiki/Aircraft_compass_turns.
+                From testing this looks enough for normal flight and pre-takeoff-calibration. -->
+            <pitch-limit-up type="float">    9 </pitch-limit-up>
+            <pitch-limit-down type="float"> -9 </pitch-limit-down>
+            <stuck type="bool"> 0 </stuck>
+        </magnetic-compass>
     </instrumentation>
     <fdm>
         <jsbsim>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -281,8 +281,10 @@ model, instrument panel, and external 3D model.
                 no better source found than "in most compasses, the bowl to tilt by approximately 18
                 degrees before it will touch the side of the casing" https://en.wikipedia.org/wiki/Aircraft_compass_turns.
                 From testing this looks enough for normal flight and pre-takeoff-calibration. -->
-            <pitch-limit-up type="float">    9 </pitch-limit-up>
-            <pitch-limit-down type="float"> -9 </pitch-limit-down>
+            <pitch-limit-up type="float">     9 </pitch-limit-up>
+            <pitch-limit-down type="float">  -9 </pitch-limit-down>
+            <roll-limit-right type="float">  25 </roll-limit-right>
+            <roll-limit-left type="float">  -25 </roll-limit-left>
             <stuck type="bool"> 0 </stuck>
         </magnetic-compass>
     </instrumentation>

--- a/c172p-set.xml
+++ b/c172p-set.xml
@@ -276,6 +276,15 @@ model, instrument panel, and external 3D model.
         <altimeter-kap140-internal>
             <serviceable type="bool">true</serviceable>
         </altimeter-kap140-internal>
+        <magnetic-compass>
+            <!-- Compass will get stuck and have bad readings when exceeding this limits in degrees.
+                no better source found than "in most compasses, the bowl to tilt by approximately 18
+                degrees before it will touch the side of the casing" https://en.wikipedia.org/wiki/Aircraft_compass_turns.
+                From testing this looks enough for normal flight and pre-takeoff-calibration. -->
+            <pitch-limit-up type="float">    9 </pitch-limit-up>
+            <pitch-limit-down type="float"> -9 </pitch-limit-down>
+            <stuck type="bool"> 0 </stuck>
+        </magnetic-compass>
     </instrumentation>
     <fdm>
         <jsbsim>

--- a/c172p-ski-set.xml
+++ b/c172p-ski-set.xml
@@ -186,8 +186,10 @@ model, instrument panel, and external 3D model.
                 no better source found than "in most compasses, the bowl to tilt by approximately 18
                 degrees before it will touch the side of the casing" https://en.wikipedia.org/wiki/Aircraft_compass_turns.
                 From testing this looks enough for normal flight and pre-takeoff-calibration. -->
-            <pitch-limit-up type="float">    9 </pitch-limit-up>
-            <pitch-limit-down type="float"> -9 </pitch-limit-down>
+            <pitch-limit-up type="float">     9 </pitch-limit-up>
+            <pitch-limit-down type="float">  -9 </pitch-limit-down>
+            <roll-limit-right type="float">  25 </roll-limit-right>
+            <roll-limit-left type="float">  -25 </roll-limit-left>
             <stuck type="bool"> 0 </stuck>
         </magnetic-compass>
     </instrumentation>

--- a/c172p-ski-set.xml
+++ b/c172p-ski-set.xml
@@ -181,6 +181,15 @@ model, instrument panel, and external 3D model.
         <altimeter-kap140-internal>
             <serviceable type="bool">true</serviceable>
         </altimeter-kap140-internal>
+        <magnetic-compass>
+            <!-- Compass will get stuck and have bad readings when exceeding this limits in degrees.
+                no better source found than "in most compasses, the bowl to tilt by approximately 18
+                degrees before it will touch the side of the casing" https://en.wikipedia.org/wiki/Aircraft_compass_turns.
+                From testing this looks enough for normal flight and pre-takeoff-calibration. -->
+            <pitch-limit-up type="float">    9 </pitch-limit-up>
+            <pitch-limit-down type="float"> -9 </pitch-limit-down>
+            <stuck type="bool"> 0 </stuck>
+        </magnetic-compass>
     </instrumentation>
     <fdm>
         <jsbsim>


### PR DESCRIPTION
Magnetic Compass enhanced
- simulated pivot mount
- can get stuck when outside the pivots pitch limits
- avionics have electrical influence on the bearing (compass correction is the same as it was before with all avionics on; by coincidence its the same)

(Ported over from the c182s)