### PR TITLE
Show rounded headings in tooltips (Mag. Compass, HI)

### DIFF
--- a/Models/Interior/Panel/Instruments/hi/hi.xml
+++ b/Models/Interior/Panel/Instruments/hi/hi.xml
@@ -88,7 +88,7 @@
                 <command>set-tooltip</command>
                 <tooltip-id>heading-bug</tooltip-id>
                 <mapping>heading</mapping>
-                <label>Heading Bug: %3d</label>
+                <label>Heading Bug: %3.0f</label>
                 <property>autopilot/settings/heading-bug-deg</property>
             </binding>
         </hovered>
@@ -127,7 +127,7 @@
             <binding>
                 <command>set-tooltip</command>
                 <tooltip-id>heading-offset</tooltip-id>
-                <label>Heading Offset: %3d</label>
+                <label>Heading Offset: %3.0f</label>
                 <mapping>heading</mapping>
                 <property>instrumentation/heading-indicator/offset-deg</property>
             </binding>

--- a/Models/Interior/Panel/Instruments/mag-compass/mag-compass.xml
+++ b/Models/Interior/Panel/Instruments/mag-compass/mag-compass.xml
@@ -127,7 +127,7 @@
             <binding>
                 <command>set-tooltip</command>
                 <tooltip-id>magnetcompass</tooltip-id>
-                <label>Magnetic heading: %3d</label>
+                <label>Magnetic heading: %3.0f</label>
                 <property>instrumentation/magnetic-compass/indicated-heading-deg-final</property>
                 <mapping>heading</mapping>
             </binding>


### PR DESCRIPTION
Currently the tooltips of the HI knobs and the magnetic compass show the heading values `floor`ed.
This PR makes them show rounded values.

Old:  `123.95` => `123`
New: `123.95` => `124`