### PR TITLE
Magnetic Compass: Clamp roll/pitch animation

### DIFF
--- a/Models/Interior/Panel/Instruments/mag-compass/mag-compass-fg1000.xml
+++ b/Models/Interior/Panel/Instruments/mag-compass/mag-compass-fg1000.xml
@@ -78,7 +78,13 @@
     <animation>
         <type>rotate</type>
         <object-name>Ring</object-name>
-        <property>instrumentation/magnetic-compass/roll-deg-final</property>
+        <expression>
+            <clip>
+                <clipMin>-25</clipMin>
+                <clipMax>25</clipMax>
+                <property>instrumentation/magnetic-compass/roll-deg-final</property>
+            </clip>
+        </expression>
         <factor>0.5</factor>
         <axis>
             <x> 1.0 </x>
@@ -94,7 +100,13 @@
     <animation>
         <type>rotate</type>
         <object-name>Ring</object-name>
-        <property>instrumentation/magnetic-compass/pitch-deg-final</property>
+        <expression>
+            <clip>
+                <clipMin>-9</clipMin>
+                <clipMax>9</clipMax>
+                <property>instrumentation/magnetic-compass/pitch-deg-final</property>
+            </clip>
+        </expression>
         <factor>0.5</factor>
         <axis>
             <x>  0.0 </x>

--- a/Models/Interior/Panel/Instruments/mag-compass/mag-compass-float-fg1000.xml
+++ b/Models/Interior/Panel/Instruments/mag-compass/mag-compass-float-fg1000.xml
@@ -66,7 +66,13 @@
     <animation>
         <type>rotate</type>
         <object-name>Ring</object-name>
-        <property>instrumentation/magnetic-compass/roll-deg-final</property>
+        <expression>
+            <clip>
+                <clipMin>-25</clipMin>
+                <clipMax>25</clipMax>
+                <property>instrumentation/magnetic-compass/roll-deg-final</property>
+            </clip>
+        </expression>
         <factor>0.5</factor>
         <axis>
             <x> 1.0 </x>
@@ -77,7 +83,13 @@
     <animation>
         <type>rotate</type>
         <object-name>Ring</object-name>
-        <property>instrumentation/magnetic-compass/pitch-deg-final</property>
+        <expression>
+            <clip>
+                <clipMin>-9</clipMin>
+                <clipMax>9</clipMax>
+                <property>instrumentation/magnetic-compass/pitch-deg-final</property>
+            </clip>
+        </expression>
         <factor>0.5</factor>
         <axis>
             <x>  0.0 </x>

--- a/Models/Interior/Panel/Instruments/mag-compass/mag-compass-float.xml
+++ b/Models/Interior/Panel/Instruments/mag-compass/mag-compass-float.xml
@@ -78,7 +78,13 @@
     <animation>
         <type>rotate</type>
         <object-name>Ring</object-name>
-        <property>instrumentation/magnetic-compass/roll-deg-final</property>
+        <expression>
+            <clip>
+                <clipMin>-25</clipMin>
+                <clipMax>25</clipMax>
+                <property>instrumentation/magnetic-compass/roll-deg-final</property>
+            </clip>
+        </expression>
         <factor>0.5</factor>
         <axis>
             <x> 1.0 </x>
@@ -89,7 +95,13 @@
     <animation>
         <type>rotate</type>
         <object-name>Ring</object-name>
-        <property>instrumentation/magnetic-compass/pitch-deg-final</property>
+        <expression>
+            <clip>
+                <clipMin>-9</clipMin>
+                <clipMax>9</clipMax>
+                <property>instrumentation/magnetic-compass/pitch-deg-final</property>
+            </clip>
+        </expression>
         <factor>0.5</factor>
         <axis>
             <x>  0.0 </x>

--- a/Models/Interior/Panel/Instruments/mag-compass/mag-compass.xml
+++ b/Models/Interior/Panel/Instruments/mag-compass/mag-compass.xml
@@ -78,7 +78,13 @@
     <animation>
         <type>rotate</type>
         <object-name>Ring</object-name>
-        <property>instrumentation/magnetic-compass/roll-deg-final</property>
+        <expression>
+            <clip>
+                <clipMin>-25</clipMin>
+                <clipMax>25</clipMax>
+                <property>instrumentation/magnetic-compass/roll-deg-final</property>
+            </clip>
+        </expression>
         <factor>0.5</factor>
         <axis>
             <x> 1.0 </x>
@@ -94,7 +100,13 @@
     <animation>
         <type>rotate</type>
         <object-name>Ring</object-name>
-        <property>instrumentation/magnetic-compass/pitch-deg-final</property>
+        <expression>
+            <clip>
+                <clipMin>-9</clipMin>
+                <clipMax>9</clipMax>
+                <property>instrumentation/magnetic-compass/pitch-deg-final</property>
+            </clip>
+        </expression>
         <factor>0.5</factor>
         <axis>
             <x>  0.0 </x>


### PR DESCRIPTION
Clamp the compass pitch and roll animation to sane values.
This is needed in case someone disables the roll/pitch stuck limits.