### PR TITLE
Add transpaent yoke hiding

### DIFF
--- a/Models/Interior/Yoke/yoke-fg1000.xml
+++ b/Models/Interior/Yoke/yoke-fg1000.xml
@@ -96,18 +96,16 @@
     </animation>
 
     <animation>
-        <type>select</type>
+        <type>material</type>
         <object-name>LeftYoke</object-name>
         <object-name>LeftYokeMain</object-name>
         <object-name>RightYoke</object-name>
         <object-name>RightYokeMain</object-name>
         <object-name>YokeCordLeft</object-name>
         <object-name>YokeCordRight</object-name>
-        <condition>
-            <not>
-                <property>sim/model/hide-yoke</property>
-            </not>
-        </condition>
+        <transparency>
+            <alpha-prop>sim/model/hide-yoke-alpha</alpha-prop>
+        </transparency>
     </animation>
 
     <animation>

--- a/Models/Interior/Yoke/yoke.xml
+++ b/Models/Interior/Yoke/yoke.xml
@@ -105,18 +105,16 @@
     </animation>
 
     <animation>
-        <type>select</type>
+        <type>material</type>
         <object-name>LeftYoke</object-name>
         <object-name>LeftYokeMain</object-name>
         <object-name>RightYoke</object-name>
         <object-name>RightYokeMain</object-name>
         <object-name>YokeCordLeft</object-name>
         <object-name>YokeCordRight</object-name>
-        <condition>
-            <not>
-                <property>sim/model/hide-yoke</property>
-            </not>
-        </condition>
+        <transparency>
+            <alpha-prop>sim/model/hide-yoke-alpha</alpha-prop>
+        </transparency>
     </animation>
 
     <animation>

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -844,3 +844,19 @@ setlistener("sim/model/variant", func (node) {
         }
     }
 }, 1, 0);
+
+
+##########
+# Handle Yoke transparency
+##########
+var updateYokeTransparency = func() {
+    var hide = getprop("/sim/model/hide-yoke") or 0;
+    if (hide == 1) {
+        alpha = getprop("sim/model/hide-yoke-alpha-cmd");
+    } else {
+        alpha = 1;
+    }
+    setprop("/sim/model/hide-yoke-alpha", alpha);
+}
+setlistener("/sim/model/hide-yoke", updateYokeTransparency, 1, 0);
+setlistener("/sim/model/hide-yoke-alpha-cmd", updateYokeTransparency, 1, 0);

--- a/c172p-main.xml
+++ b/c172p-main.xml
@@ -239,6 +239,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             </c172p>
 
             <hide-yoke type="bool">false</hide-yoke>
+            <hide-yoke-alpha-cmd>0.25</hide-yoke-alpha-cmd>
 
             <crew>
                 <pilot n="0">
@@ -360,6 +361,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <path>/sim/model/c172p/save-state</path>
             <path>/engines/active-engine/complex-engine-procedures</path>
             <path>/sim/model/immat</path>
+            <path>/sim/model/hide-yoke-alpha-cmd</path>
             <path>/controls/mooring/automatic</path>
             <path>/sim/current-view/user/x-offset-m</path>
             <path>/sim/current-view/user/y-offset-m</path>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -220,6 +220,36 @@
 
         </group>
 
+        <group>
+            <layout>hbox</layout>
+            <halign>left</halign>
+
+            <checkbox>
+                <halign>left</halign>
+                <label>Show/Hide Yokes</label>
+                <property>/sim/model/hide-yoke</property>
+                <live>true</live>
+                <binding>
+                    <command>property-toggle</command>
+                    <property>/sim/model/hide-yoke</property>
+                </binding>
+                <binding>
+                    <command>dialog-update</command>
+                </binding>
+            </checkbox>
+            <slider>
+                <name>c172-yokealpha-slider</name>
+                <min>0</min>
+                <max>1.0</max>
+                <live>true</live>
+                <property>/sim/model/hide-yoke-alpha-cmd</property>
+                <binding>
+                    <command>dialog-apply</command>
+                    <name>c172-yokealpha-slider</name>
+                </binding>
+            </slider>
+        </group>
+
         <hrule/>
 
         <group>


### PR DESCRIPTION
Added yoke transparency.

Yoke is not hidden completely anymore, but made transparent, so pilot can still see the yoke while being able to see instruments behind it.

Transparency setting is stored between sessions.

For more Details also see: https://github.com/HHS81/c182s/pull/392


![grafik](https://github.com/c172p-team/c172p/assets/13608602/3715e0f3-5769-4291-9b39-1085e0702de6)

![grafik](https://github.com/c172p-team/c172p/assets/13608602/08017f3c-84e5-4581-a5b4-0254cbcb031a)

![grafik](https://github.com/c172p-team/c172p/assets/13608602/236920cd-82e8-4cd2-86cf-e4678c971e0d)

![grafik](https://github.com/c172p-team/c172p/assets/13608602/981310c9-680d-4569-ab64-14cb717af305)
