### PR TITLE
Flashlight: synchronize with walker flashlight

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -4177,6 +4177,93 @@
         <object-name>courtesy-r-fg1000</object-name>
     </animation>
 
+    <!-- Flashlight -->
+    <light>
+        <name>c172_flashlight</name>
+        <type>spot</type>
+        <position>
+            <x-m>0.212</x-m>
+            <y-m>-0.183</y-m>
+            <z-m>0.20</z-m>
+        </position>
+        <direction>
+            <pitch-deg>90</pitch-deg>
+            <roll-deg>0</roll-deg>
+            <heading-deg>0</heading-deg>
+        </direction>
+        <ambient>
+            <r><property>sim/walker/flashlight/color-red-factor</property></r>
+            <g><property>sim/walker/flashlight/color-green-factor</property></g>
+            <b><property>sim/walker/flashlight/color-blue-factor</property></b>
+            <a>1</a>
+        </ambient>
+        <diffuse>
+            <r><property>sim/walker/flashlight/color-red-factor</property></r>
+            <g><property>sim/walker/flashlight/color-green-factor</property></g>
+            <b><property>sim/walker/flashlight/color-blue-factor</property></b>
+            <a>1</a>
+        </diffuse>
+        <specular>
+            <r><property>sim/walker/flashlight/color-red-factor</property></r>
+            <g><property>sim/walker/flashlight/color-green-factor</property></g>
+            <b><property>sim/walker/flashlight/color-blue-factor</property></b>
+            <a>1</a>
+        </specular>
+        <attenuation>
+            <c>1.0</c>
+            <l>0.09</l>
+            <q>0.032</q>
+        </attenuation>
+        <dim-factor><property>sim/walker/flashlight/dim-factor</property></dim-factor>
+        <spot-exponent>45</spot-exponent>
+        <spot-cutoff>50</spot-cutoff>
+        <range-m>10</range-m>
+    </light>
+    <animation>
+        <type>select</type>
+        <object-name>c172_flashlight</object-name>
+        <condition>
+            <and>
+            <greater-than>
+                <property>/sim/walker/flashlight/mode</property>
+                <value>0</value>
+            </greater-than>
+            <property>/sim/current-view/internal</property>
+            </and>
+        </condition>
+    </animation>
+    <animation>
+        <type>rotate</type>
+        <object-name>c172_flashlight</object-name>
+        <property>sim/current-view/heading-offset-deg</property>
+        <center>
+            <x-m>0.212</x-m>
+            <y-m>-0.183</y-m>
+            <z-m>0.20</z-m>
+        </center>
+        <axis>
+            <x>0</x>
+            <y>0</y>
+            <z>1</z>
+        </axis>
+    </animation>
+    <animation>
+        <type>rotate</type>
+        <object-name>c172_flashlight</object-name>
+        <property>sim/current-view/pitch-offset-deg</property>
+        <center>
+            <x-m>0.212</x-m>
+            <y-m>-0.183</y-m>
+            <z-m>0.20</z-m>
+        </center>
+        <axis>
+            <x>0</x>
+            <y>1</y>
+            <z>0</z>
+        </axis>
+    </animation>
+
+
     <!-- ================================================================== -->
     <!-- Lighting adjustments due to wing damage                            -->
     <!-- ================================================================== -->

--- a/Nasal/interior-lighting.nas
+++ b/Nasal/interior-lighting.nas
@@ -15,16 +15,24 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 # ALS flashlight
-	var toggle_flashlight = func {
+var toggle_flashlight = func {
 	if (getprop("/sim/rendering/shaders/skydome")) {
 		var old_value = getprop("/sim/rendering/als-secondary-lights/use-flashlight");
 		var new_value = math.mod(old_value + 1, 3);
 		setprop("/sim/rendering/als-secondary-lights/use-flashlight", new_value);
-	}
+		setprop("/sim/walker/flashlight/mode", new_value);
+    }
 	else {
 		gui.popupTip("Enable ALS for ALS Flashlight", 4);
 	}
 };
+
+setlistener("sim/walker/flashlight/mode", func(n) {
+	# detect walker flashlight use and activate ours too
+	if (n.getValue() != getprop("/sim/rendering/als-secondary-lights/use-flashlight"))
+		toggle_flashlight();
+});
+
 
 # Dome lights
 var toggle_domelight = func {

--- a/Nasal/interior-lighting.nas
+++ b/Nasal/interior-lighting.nas
@@ -14,26 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# ALS flashlight
-var toggle_flashlight = func {
-	if (getprop("/sim/rendering/shaders/skydome")) {
-		var old_value = getprop("/sim/rendering/als-secondary-lights/use-flashlight");
-		var new_value = math.mod(old_value + 1, 3);
-		setprop("/sim/rendering/als-secondary-lights/use-flashlight", new_value);
-		setprop("/sim/walker/flashlight/mode", new_value);
-    }
-	else {
-		gui.popupTip("Enable ALS for ALS Flashlight", 4);
-	}
-};
-
-setlistener("sim/walker/flashlight/mode", func(n) {
-	# detect walker flashlight use and activate ours too
-	if (n.getValue() != getprop("/sim/rendering/als-secondary-lights/use-flashlight"))
-		toggle_flashlight();
-});
-
-
 # Dome lights
 var toggle_domelight = func {
     var old_value = getprop("/sim/model/c172p/lighting/dome-norm");

--- a/Tutorials/amphibious-night.xml
+++ b/Tutorials/amphibious-night.xml
@@ -483,7 +483,7 @@ Pay attention to the heading bug on taxiing it will approximate the threshold po
             <message>Turn off your flashlight, press [f] key until off.</message>
             <condition>
                 <greater-than>
-                    <property>/sim/rendering/als-secondary-lights/use-flashlight</property>
+                    <property>/sim/walker/flashlight/mode</property>
                     <value>0</value>
                 </greater-than>
             </condition>
@@ -498,7 +498,7 @@ Pay attention to the heading bug on taxiing it will approximate the threshold po
                     <property>/controls/lighting/beacon</property>
                     <property>/controls/lighting/strobe</property>
                     <equals>
-                        <property>/sim/rendering/als-secondary-lights/use-flashlight</property>
+                        <property>/sim/walker/flashlight/mode</property>
                         <value>0</value>
                     </equals>
                 </and>

--- a/c172p-keyboard.xml
+++ b/c172p-keyboard.xml
@@ -61,8 +61,11 @@
         <desc>Toggle flashlight</desc>
         <repeatable type="bool">true</repeatable>
         <binding>
-            <command>nasal</command>
-            <script>c172p.toggle_flashlight()</script>
+            <command>property-cycle</command>
+            <property>/sim/walker/flashlight/mode</property>
+            <value type="int">0</value> <!-- off -->
+            <value type="int">1</value> <!-- white -->
+            <value type="int">2</value> <!-- red -->
         </binding>
     </key>
 
@@ -71,8 +74,11 @@
         <desc>Toggle flashlight</desc>
         <repeatable type="bool">true</repeatable>
         <binding>
-            <command>nasal</command>
-            <script>c172p.toggle_flashlight()</script>
+            <command>property-cycle</command>
+            <property>/sim/walker/flashlight/mode</property>
+            <value type="int">0</value> <!-- off -->
+            <value type="int">1</value> <!-- white -->
+            <value type="int">2</value> <!-- red -->
         </binding>
     </key>
     

--- a/gui/dialogs/c172p-menu.xml
+++ b/gui/dialogs/c172p-menu.xml
@@ -51,14 +51,11 @@
             <item>
                 <label>Flashlight</label>
                 <binding>
-                    <command>nasal</command>
-                    <binding>
-                        <command>property-cycle</command>
-                        <property>/sim/walker/flashlight/mode</property>
-                        <value type="int">0</value> <!-- off -->
-                        <value type="int">1</value> <!-- white -->
-                        <value type="int">2</value> <!-- red -->
-                    </binding>
+                    <command>property-cycle</command>
+                    <property>/sim/walker/flashlight/mode</property>
+                    <value type="int">0</value> <!-- off -->
+                    <value type="int">1</value> <!-- white -->
+                    <value type="int">2</value> <!-- red -->
                 </binding>
             </item>
 

--- a/gui/dialogs/c172p-menu.xml
+++ b/gui/dialogs/c172p-menu.xml
@@ -52,7 +52,13 @@
                 <label>Flashlight</label>
                 <binding>
                     <command>nasal</command>
-                    <script>c172p.toggle_flashlight()</script>
+                    <binding>
+                        <command>property-cycle</command>
+                        <property>/sim/walker/flashlight/mode</property>
+                        <value type="int">0</value> <!-- off -->
+                        <value type="int">1</value> <!-- white -->
+                        <value type="int">2</value> <!-- red -->
+                    </binding>
                 </binding>
             </item>
 


### PR DESCRIPTION
The FGData walker now also got a flashlight (only NEXT!).
This change makes the cockpit-ALS and walker-compositor flashlight synchron, so switching on the light in the cockpit makes the flashlight on when stepping out of the plane (and vice versa).

Also, as a positive side effect, the walkers (standard) keybind CTRL+F is now operable and switching also the ALS cockpit flashlight.

- - -
- C182 sister PR: https://github.com/HHS81/c182s/pull/558