### PR TITLE
Towbar: Release force instantly instead of "slow" decay

### DIFF
--- a/Models/Exterior/towbar/towbar.xml
+++ b/Models/Exterior/towbar/towbar.xml
@@ -133,12 +133,10 @@
 			</binding>
 			
 			<mod-up>
-				<!-- slowly decay push/pull force -->
 				<binding>
-					<command>property-interpolate</command>
+					<command>property-assign</command>
 					<property>fdm/jsbsim/external_reactions/towbar/magnitude</property>
 					<value type="double">0</value>
-					<rate>50</rate>
 				</binding>
 				
 				<!-- reset mouse position memories -->


### PR DESCRIPTION
This helps with a small bug with quick clicks not "gripping". Handling does not make a difference.