### PR TITLE
Update gyro instruments to current "next" enhancements

### DIFF
--- a/Models/Interior/Panel/Instruments/hi/hi.xml
+++ b/Models/Interior/Panel/Instruments/hi/hi.xml
@@ -95,10 +95,10 @@
     </animation>
 
     <!-- Heading Offset -->
-    <animation>
+<!--    <animation>
         <type>knob</type>
         <object-name>OBS-Knob</object-name>
-        <property>instrumentation/heading-indicator/offset-deg</property>
+        <property>instrumentation/heading-indicator/align-deg</property>
         <factor>12</factor>
         <axis>
             <x>-1</x>
@@ -113,14 +113,13 @@
         <action>
             <binding>
                 <command>property-adjust</command>
-                <property>instrumentation/heading-indicator/offset-deg</property>
+                <property>instrumentation/heading-indicator/align-deg</property>
                 <factor>1</factor>
                 <min>0</min>
                 <max>360</max>
                 <wrap>1</wrap>
             </binding>
         </action>
-        <!-- Faster rate of change than the default -->
         <drag-scale-px>4</drag-scale-px>
         <shift-repeat type="int">5</shift-repeat>
         <hovered>
@@ -129,10 +128,158 @@
                 <tooltip-id>heading-offset</tooltip-id>
                 <label>Heading Offset: %3.0f</label>
                 <mapping>heading</mapping>
-                <property>instrumentation/heading-indicator/offset-deg</property>
+                <property>instrumentation/heading-indicator/align-deg</property>
             </binding>
         </hovered>
+    </animation>-->
+    <animation>
+        <type>translate</type>
+        <object-name>OBS-Knob</object-name>
+        <property>instrumentation/heading-indicator/caged-flag</property>
+        <factor>0.004</factor>
+        <axis>
+            <x>-1.0</x>
+            <y>0.0</y>
+            <z>0.0</z>
+        </axis>
     </animation>
+    <animation>
+        <type>knob</type>
+        <object-name>OBS-Knob</object-name>
+        <property>instrumentation/heading-indicator/align-deg</property>
+        <factor>12</factor>
+        <axis>
+            <x>-1</x>
+            <y>0</y>
+            <z>0</z>
+        </axis>
+        <center>
+            <x-m>-0.36799</x-m>
+            <y-m>-0.25151</y-m>
+            <z-m>-0.03297</z-m>
+        </center>
+        <action>
+            <binding>
+                <command>property-adjust</command>
+                <property>instrumentation/heading-indicator/align-deg</property>
+                <factor>1</factor>
+                <min>0</min>
+                <max>360</max>
+                <wrap>1</wrap>
+            </binding>
+            <binding>
+                <command>nasal</command>
+                <script><![CDATA[
+                    # Cage gyro when moving
+                    var oldSetting = getprop("instrumentation/heading-indicator/caged-flag");
+                    if (!oldSetting) {
+                    setprop("instrumentation/heading-indicator/caged-flag", 1);
+                    
+                    var rotateAction = maketimer(1.0, func {
+                        setprop("instrumentation/heading-indicator/caged-flag", 0);
+                    });
+                    rotateAction.singleShot = 1;
+                    rotateAction.start();
+                    }
+                ]]></script>
+            </binding>
+            <binding>
+                <command>nasal</command>
+                <script>c172p.click("heading-offset-dial")</script>
+            </binding>
+        </action>
+        <shift-action>
+            <binding>
+                <condition>
+                    <greater-than>
+                        <property>/sim/time/elapsed-sec</property>
+                        <expression>
+                        <sum>
+                            <property>/instrumentation/heading-indicator/obs_last-shift-click</property>
+                            <value>1</value>
+                        </sum>
+                        </expression>
+                    </greater-than>
+                </condition>
+                <command>property-toggle</command>
+                <property>instrumentation/heading-indicator/caged-flag</property>
+            </binding>
+
+            <binding>
+                <condition>
+                    <less-than-equals>
+                        <property>/sim/time/elapsed-sec</property>
+                        <expression>
+                        <sum>
+                            <property>/instrumentation/heading-indicator/obs_last-shift-click</property>
+                            <value>1</value>
+                        </sum>
+                        </expression>
+                    </less-than-equals>
+                </condition>
+                <command>property-adjust</command>
+                <property>instrumentation/heading-indicator/align-deg</property>
+                <factor>5</factor>
+                <min>0</min>
+                <max>360</max>
+                <wrap>1</wrap>
+            </binding>
+            <binding>
+                <condition>
+                <less-than-equals>
+                    <property>/sim/time/elapsed-sec</property>
+                    <expression>
+                    <sum>
+                        <property>/instrumentation/heading-indicator/obs_last-shift-click</property>
+                        <value>1</value>
+                    </sum>
+                    </expression>
+                </less-than-equals>
+                </condition>
+                <command>nasal</command>
+                <script><![CDATA[
+                    # Cage gyro when moving, uncage afterwards
+                    setprop("instrumentation/heading-indicator/caged-flag", 1);
+                    
+                    var rotateAction = maketimer(1.0, func {
+                        setprop("instrumentation/heading-indicator/caged-flag", 0);
+                    });
+                    rotateAction.singleShot = 1;
+                    rotateAction.start();
+                ]]></script>
+            </binding>
+            <binding>
+                <command>property-assign</command>
+                <property>/instrumentation/heading-indicator/obs_last-shift-click</property>
+                <property>/sim/time/elapsed-sec</property>
+            </binding>
+            <binding>
+                <command>nasal</command>
+                <script>c172p.click("heading-offset-dial")</script>
+            </binding>
+        </shift-action>
+    
+        <!-- faster rate of change than the default -->
+        <drag-scale-px>4</drag-scale-px>
+        
+        <hovered>
+            <binding>
+                <command>set-tooltip</command>
+                <tooltip-id>heading-offset</tooltip-id>
+                <label>%s</label>
+                <property>/instrumentation/heading-indicator/indicated-heading-deg</property>
+                <mapping>nasal</mapping>
+                <script>
+                    var heading = getprop("instrumentation/heading-indicator/indicated-heading-deg");
+                    var returnString = "Heading: " ~ sprintf("%3.0f", heading);
+                    if (getprop("instrumentation/heading-indicator/caged-flag")) {
+                        returnString = returnString ~ "\n(caged)";
+                    }
+                    return returnString;
+                </script>
+            </binding>
+        </hovered>
+   </animation>
 
     <effect>
         <inherits-from>../../../../Effects/interior/lm-hi</inherits-from>

--- a/Nasal/avionics.nas
+++ b/Nasal/avionics.nas
@@ -88,10 +88,16 @@ aircraft.data.add(
 
 # Instruments
 aircraft.data.add(
+    "sim/realism/instruments/realistic-instruments",
     "instrumentation/altimeter/setting-inhg",
     "instrumentation/attitude-indicator/horizon-offset-deg",
     "autopilot/settings/heading-bug-deg",
-    "instrumentation/heading-indicator/offset-deg",
+    "orientation/heading-deg-saved",
+    "instrumentation/heading-indicator/align-deg",
+    "instrumentation/heading-indicator/caged-flag",
+    "instrumentation/heading-indicator/latitude-nut-setting",
+    "instrumentation/heading-indicator/offset-deg-saved",
+    "instrumentation/heading-indicator/error-deg-saved",
     "instrumentation/adf[0]/rotation-deg",
     "instrumentation/adf[0]/frequencies/dial-1-khz",
     "instrumentation/adf[0]/frequencies/dial-100-khz",

--- a/Nasal/c172p.nas
+++ b/Nasal/c172p.nas
@@ -87,9 +87,19 @@ var autostart = func (msg=1) {
     var pressure_sea_level = getprop("/environment/pressure-sea-level-inhg");
     setprop("/instrumentation/altimeter/setting-inhg", pressure_sea_level);
 
+    # Insta-Spin up gyros
+    setprop("/instrumentation/heading-indicator/spin", 1.0);
+    setprop("/instrumentation/turn-indicator/spin", 1.0);
+    setprop("/instrumentation/attitude-indicator/spin", 1.0);
+
     # Set heading offset
+    # Note: this needs a correctly spun up gyro to work.
     var magnetic_variation = getprop("/environment/magnetic-variation-deg");
-    setprop("/instrumentation/heading-indicator/offset-deg", -magnetic_variation);
+    magnetic_variation     = sprintf("%.2f", magnetic_variation);
+    setprop("/instrumentation/heading-indicator/align-deg", -magnetic_variation);
+    setprop("/instrumentation/heading-indicator/error-deg", 0);
+    setprop("/instrumentation/heading-indicator/offset-deg", 0);
+    print("Heading Indicator calibrated to: " ~ magnetic_variation ~ " magVar");
 
     # Pre-flight inspection
     setprop("/sim/model/c172p/cockpit/control-lock-placed", 0);
@@ -552,6 +562,95 @@ StaticModel.new("externalheater", "Aircraft/c172p/Models/Exterior/external-heate
 # Mooring anchor and rope
 StaticModel.new("anchorbuoy", "Aircraft/c172p/Models/Effects/pontoon/mooring.xml");
 
+
+#
+# Realism settings
+#
+var latitude_nut_update = func() {
+    var p = "/instrumentation/heading-indicator/latitude-nut-setting";
+    var lat = getprop("position/latitude-deg");
+    var tgt = sprintf("%2.0f", lat);
+    var cur = sprintf("%2.0f", getprop(p));
+    if (tgt != cur) {
+        setprop(p, tgt);
+        print("C172 HI/DG latitude nut adjusted from "~cur~"° to "~tgt~"°");
+    }
+}
+var latitude_nut_setter_timer = maketimer(30.0, latitude_nut_update);
+
+# Define realism adjustments. Default values here are the "unrealistic" settings.
+var prev_realism_state = [
+    {
+        id:"attitude-indicator",
+        node: props.globals.getNode("/instrumentation/attitude-indicator"),
+        props:[
+            {name:"gyro/spin-up-sec",        value:4.0}
+        ]
+    },
+    {
+        id:"heading-indicator",
+        node: props.globals.getNode("/instrumentation/heading-indicator"),
+        props:[
+            {name:"gyro/spin-up-sec",        value:4.0},
+            {name:"limits/g-error-factor",   value:0.0},
+            {name:"limits/yaw-error-factor", value:0.0},
+            {name:"limits/g-limit-lower",    value:-99.0},
+            {name:"limits/g-limit-upper",    value:99.0}
+        ]
+    },
+    {
+        id:"turn-indicator",
+        node: props.globals.getNode("/instrumentation/turn-indicator"),
+        props:[
+            {name:"gyro/spin-up-sec",        value:4.0}
+        ]
+    },
+    {
+        id:"magnetic-compass",
+        node: props.globals.getNode("/instrumentation/magnetic-compass"),
+        props:[
+            {name:"roll-limit-left",        value:-999.0},
+            {name:"roll-limit-right",       value:999.0},
+            {name:"pitch-limit-up",         value:999.0},
+            {name:"pitch-limit-down",       value:-999.0}
+        ]
+    },
+];
+var setRealismInstruments_setting = 1;
+var setRealismInstruments = func() {
+    var activate    = getprop("/sim/realism/instruments/realistic-instruments");
+    if (activate == setRealismInstruments_setting) return;
+
+    setRealismInstruments_setting = activate;
+    var setting_txt = (activate)? "enabled": "disabled";
+    print("C172 realistic instruments: "~setting_txt);
+
+    # Swap the current value with the old one for each defined prop
+    foreach (item; prev_realism_state) {
+        print("  "~item.id);
+        foreach (p; item.props) {
+            var cur_val = item.node.getValue(p.name);
+            #print("    "~p.name~ "\t\t(old="~cur_val~"; new="~p.value~")");
+            item.node.setValue(p.name, p.value);
+            p.value = cur_val;
+        }
+    }
+    
+    # Do some specific actions
+    if (activate) {
+        # Activate realistic behaviour
+        latitude_nut_setter_timer.stop();
+        print("  HI/DG latitude nut autoset stopped");
+
+    } else {
+        # Make unrealistic
+        latitude_nut_update();
+        latitude_nut_setter_timer.start();
+        print("  HI/DG latitude nut autoset activated");
+    }
+
+}
+
 ############################################
 # Global loop function
 # If you need to run nasal as loop, add it in this function
@@ -780,6 +879,51 @@ setlistener("/sim/signals/fdm-initialized", func {
         if (getprop("/sim/model/c172p/securing/tiedownL"))
             setprop("/sim/model/c172p/securing/tiedownL-visible", 1);
     }, 10);
+
+
+    # HI/DG: Reset offset to stored values
+    # The DG always initializes to indicated_heading=/orientation/heading-deg, so we need to apply the
+    # difference of the last known orientation to offset the HI, so it shows the last stored value.
+    # The result is, that the HI is only correctly aligned when the planes location and orientation did
+    # not change between sessions AND it was calibrated correctly.
+    # (This all would be alot easier if the c++ instrument would initialize to saved values)
+    var dg_offset_storemode = 0;
+    var dg_hdg_cur      = props.globals.getNode("/orientation/heading-deg");
+    var dg_hdg_saved    = props.globals.getNode("/orientation/heading-deg-saved", 1);
+    var dg_offset_cur   = props.globals.getNode("/instrumentation/heading-indicator/offset-deg");
+    var dg_offset_saved = props.globals.getNode("/instrumentation/heading-indicator/offset-deg-saved", 1);
+    var dg_error_cur    = props.globals.getNode("/instrumentation/heading-indicator/error-deg");
+    var dg_error_saved  = props.globals.getNode("/instrumentation/heading-indicator/error-deg-saved", 1);
+    
+    # Restore values from last session
+    if (dg_hdg_saved.getValue() != nil and dg_offset_saved.getValue() != nil and dg_error_saved.getValue() != nil) {
+        print("C172 restore HI/DG settings...");
+        print("  HI/DG startup error: "~sprintf("%.2f",dg_error_saved.getValue()));
+        dg_error_cur.setDoubleValue(dg_error_saved.getValue());
+        
+        print("  HI/DG startup offset: "~sprintf("%.2f",dg_offset_saved.getValue()));
+        dg_offset_cur.setDoubleValue(dg_offset_saved.getValue());
+        
+        # Apply orientation difference from last session
+        var hdg_diff           = dg_hdg_saved.getValue() - dg_hdg_cur.getValue();
+        var dg_offset_startup  = dg_offset_cur.getValue() + hdg_diff;
+        print("  HI/DG startup heading: from "~sprintf("%.2f",dg_offset_cur.getValue())~" to "~sprintf("%.2f",dg_offset_startup)~" (stored orientation diff="~sprintf("%.2f", hdg_diff)~")");
+        dg_offset_cur.setDoubleValue(dg_offset_startup);
+    }
+    
+    # Store values for next session (as we can't store the instruments values itself, they get overwritten)
+    var dg_offset_startup_timer = maketimer(1.0, func(){
+            dg_hdg_saved.setDoubleValue(dg_hdg_cur.getValue());
+            #print("C172 updating stored HI/DG heading to "~dg_hdg_saved.getValue());
+            dg_offset_saved.setDoubleValue(dg_offset_cur.getValue());
+            #print("C172 updating stored HI/DG offset to "~dg_offset_saved.getValue());
+            dg_error_saved.setDoubleValue(dg_error_cur.getValue());
+            #print("C172 updating stored HI/DG error to "~dg_error_saved.getValue());
+    });
+    dg_offset_startup_timer.start();
+    
+    # Handle realism settings
+    setlistener("/sim/realism/instruments/realistic-instruments", setRealismInstruments, 1, 0);
 
     c172_timer.start();
 });

--- a/Systems/instrumentation.xml
+++ b/Systems/instrumentation.xml
@@ -57,6 +57,15 @@ file, these values will be used (they are hardcoded).
         <name>attitude-indicator</name>
         <number>0</number>
         <suction>/systems/vacuum/suction-inhg</suction>
+        <limits>
+            <spin-thresh>0.8</spin-thresh>
+            <max-roll-error-deg>40.0</max-roll-error-deg>
+            <max-pitch-error-deg>12.0</max-pitch-error-deg>
+        </limits>
+        <gyro>
+            <spin-up-sec>180.0</spin-up-sec>     <!-- ~3 minutes -->
+            <spin-down-sec>300.0</spin-down-sec> <!-- ~5 minutes -->
+        </gyro>
     </attitude-indicator>
 
     <clock>
@@ -82,11 +91,25 @@ file, these values will be used (they are hardcoded).
         <number>0</number>
     </marker-beacon>
 
-    <heading-indicator>
+    <heading-indicator-dg>
         <name>heading-indicator</name>
         <number>0</number>
         <suction>/systems/vacuum/suction-inhg</suction>
-    </heading-indicator>
+        <minimum-vacuum>4.0</minimum-vacuum>  <!-- source: https://www.kellymfg.com/images/RC%20ALLEN%20Catalog.pdf -->
+        <limits>
+            <yaw-limit-rate>11.5</yaw-limit-rate> <!-- about 55° bank, from video footage, see refs in https://github.com/HHS81/c182s/pull/527 -->
+            <yaw-error-factor>0.033</yaw-error-factor>
+            <g-limit-lower>-0.85</g-limit-lower>
+            <g-limit-upper>2.0</g-limit-upper>
+            <g-error-factor>0.033</g-error-factor>
+            <g-limit-tumble-factor>1.5</g-limit-tumble-factor>
+        </limits>
+        <gyro>
+            <minimum-spin-norm>0.8</minimum-spin-norm>
+            <spin-up-sec>180.0</spin-up-sec>     <!-- ~3 minutes -->
+            <spin-down-sec>300.0</spin-down-sec> <!-- ~5 minutes -->
+        </gyro>
+    </heading-indicator-dg>
 
     <magnetic-compass>
         <name>magnetic-compass</name>
@@ -134,6 +157,10 @@ file, these values will be used (they are hardcoded).
     <turn-indicator>
         <name>turn-indicator</name>
         <number>0</number>
+        <gyro>
+            <spin-up-sec>180.0</spin-up-sec>     <!-- ~3 minutes -->
+            <spin-down-sec>300.0</spin-down-sec> <!-- ~5 minutes -->
+        </gyro>
     </turn-indicator>
 
     <vertical-speed-indicator>

--- a/c172p-main.xml
+++ b/c172p-main.xml
@@ -47,7 +47,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
 
         <status>advanced production</status>
         <aircraft-version>2020.5.1-git</aircraft-version>
-        <minimum-fg-version>2020.3.18</minimum-fg-version>
+        <minimum-fg-version>2020.4.0</minimum-fg-version>
         <rating>
             <FDM type="int">5</FDM>
             <systems type="int">5</systems>

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -43,6 +43,11 @@
             setprop("sim/model/c172p/tank_flag_0", 0);
             setprop("sim/model/c172p/tank_flag_1", 0);
             setprop("sim/model/c172p/tank_flag_" ~ p, 1);
+
+            # Ensure latitude nut has a value
+            var latnutprop = "/instrumentation/heading-indicator/latitude-nut-setting";
+            if (!getprop(latnutprop))
+                setprop(latnutprop, 0);
         </open>
     </nasal>
 
@@ -818,6 +823,54 @@
                 </binding>
             </button>
         </group>
+    </group>
+
+    <hrule/>
+
+    <group>
+        <layout>hbox</layout>
+        <checkbox>
+            <halign>left</halign>
+            <label>Realistic Instruments</label>
+            <property>/sim/realism/instruments/realistic-instruments</property>
+            <live>true</live>
+            <binding>
+                <command>property-toggle</command>
+                <property>/sim/realism/instruments/realistic-instruments</property>
+            </binding>
+            <binding>
+                <command>dialog-update</command><!-- makes sure that command is still there when dialog is closed-->
+            </binding>
+        </checkbox>
+    </group>
+    
+    <group>
+        <layout>hbox</layout>
+
+        <text>
+            <label>HI/DG Latitude Nut setting:</label>
+            <halign>left</halign>
+        </text>
+    
+        <input>
+            <name>latitude-nut-setting</name>
+            <halign>left</halign>
+            <property>/instrumentation/heading-indicator/latitude-nut-setting</property>
+            <type>INT</type>
+            <width>2</width>
+        </input>
+        <button>
+            <legend>Apply</legend>
+            <equal>true</equal>
+            <default>false</default>
+            <binding>
+                <command>dialog-apply</command>
+                <object-name>latitude-nut-setting</object-name>
+            </binding>
+            <binding>
+                <command>dialog-close</command>
+            </binding>
+        </button>
     </group>
 
     <hrule/>


### PR DESCRIPTION
**Update gyro instruments to current "next" enhancements**

This I made "opt-in", so the pilot needs to activate this from the aircraft options menu.
  If this is not activated at startup, it will adjust the instruments config to not exhibit
  errors. The instruments will work always good, not wander and not tumble; also
  they will spinup very fast (few seconds, like previously).

Gyros will have more realistic behaviour:
* HI, AI and TC: the gyro spinup will take longer (about 2-3 minutes).
* HI:
  - can be caged now, and when adjusting the disc, it will realistically cage while moving. Cage can be toggled by shift-click on the knob. The knob appears pushed and the tooltip will also report a hint to the user.
  - can tumble now with high G loads
  - models errors (drift/precession due to latitude (transport wander, high yaw-forces))
  - has latitude nut simulation (factory setting to be set in aircraft options)

Settings are stored between sessions.
Autostart will spin up all gyros instantly (as if they have already run for some time) and HI is aligned (while removing all erros/drift from the instrument).

:warning:  Needs a change from FGFS 2020.4/next, so not compatible to 2020.3/stable!

-----
**Refs:**
* Related SF Ticket: https://sourceforge.net/p/flightgear/codetickets/2839/
* Mailing list discussion: https://sourceforge.net/p/flightgear/mailman/flightgear-devel/thread/6e66f08e3fb3f02a9d5c557cfd7a2910%40hallinger.org/#msg53245268
* C182s sister ticket: https://github.com/HHS81/c182s/pull/527
* FGFS Wiki Newsletter Jan/2024: https://wiki.flightgear.org/FlightGear_Newsletter_January_2024#Gyro_based_instruments_enhancements