### PR TITLE
Add default props/values for vertical-speed-indicator

### DIFF
--- a/c172p-main.xml
+++ b/c172p-main.xml
@@ -852,6 +852,10 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
         <airspeed-indicator>
             <serviceable type="bool">true</serviceable>
         </airspeed-indicator>
+        <vertical-speed-indicator>
+            <indicated-speed-fpm type="double">0</indicated-speed-fpm>
+            <indicated-speed-mps type="double">0</indicated-speed-mps>
+        </vertical-speed-indicator>
         <save-switches-state type="bool">false</save-switches-state>
     </instrumentation>
 


### PR DESCRIPTION
This adds compatibility to the landing_rate_addon https://github.com/RenanMsV/landing_rate

See also C182 sister ticket: https://github.com/HHS81/c182s/issues/562