### PR TITLE
172sp elec

### DIFF
--- a/Models/Interior/Panel/c172sp-panel/c172sp.xml
+++ b/Models/Interior/Panel/c172sp-panel/c172sp.xml
@@ -514,6 +514,8 @@
         <type>knob</type>
         <object-name>toggle-stbybatt</object-name>
         <property>controls/switches/stby-batt</property>
+        <drag-direction>vertical</drag-direction>
+        <drag-scale-px>20</drag-scale-px>
         <offset>-15</offset>
         <factor>-30</factor>
         <center>
@@ -539,31 +541,15 @@
                 <command>nasal</command>
                 <script>c172p.click("avionics")</script>
             </binding>
-            <binding>
-                <command>nasal</command>
-                <script>
-                    var switch_pos = getprop("controls/switches/stby-batt");
-                    if (switch_pos == 1) {
-                        setprop("controls/lighting/batt-test-lamp-norm", 0);
-                    } else
-                    if (switch_pos == 0) {
-                        setprop("controls/lighting/batt-test-lamp-norm", 1);  
-                    }
-                </script>
-            </binding>
         </action>
+        <!-- Release action, limit to 1 and 2. 0 is spring loaded TEST position -->
         <release>
             <binding>
-                <command>nasal</command>
-                <script>
-                    var switch_pos = getprop("controls/switches/stby-batt");
-                    if (switch_pos == 0) {
-                        settimer(func(){
-                            setprop("controls/switches/stby-batt", 1);
-                            setprop("controls/lighting/batt-test-lamp-norm", 0);
-                        }, 5);
-                    }
-                </script>
+                <command>property-adjust</command>
+                <property>controls/switches/stby-batt</property>
+                <step>0</step>
+                <min>1</min>
+                <max>2</max>
             </binding>
         </release>
         <hovered>

--- a/Nasal/electrical-fg1000.nas
+++ b/Nasal/electrical-fg1000.nas
@@ -392,21 +392,21 @@ var update_virtual_bus = func (dt) {
     var eammeter = 0.0;
     if ( power_source == "battery_stby") {
         eammeter = -load_ess;
-        if (eammeter < 0.5) {
-            settimer(func(){
-                if (eammeter < 0.5) {
-                    setprop("controls/lighting/batt-test-lamp-norm", 1);
-                }
-            }, 10.0)
-        }
-    } else
+    } else {
         if ( master_bat_stby == 2 and power_source == "alternator") {
             eammeter = battery_stby.charge_amps;
-            setprop("controls/lighting/batt-test-lamp-norm", 0);
         } else {
             eammeter = 0;
-            setprop("controls/lighting/batt-test-lamp-norm", 0);
         }
+    }
+
+    # calculate stby bat test light illumination
+    # This is showing the battery life, nothing else.
+    var batt_test_lamp = 0.0;
+    if (master_bat_stby == 0) {
+        batt_test_lamp = getprop("systems/electrical/battery-charge-percent/b");
+    }
+    setprop("controls/lighting/batt-test-lamp-norm", batt_test_lamp);
 
     # charge/discharge the battery
     if (power_source == "battery") {

--- a/Nasal/electrical-fg1000.nas
+++ b/Nasal/electrical-fg1000.nas
@@ -37,6 +37,8 @@ var master_av1 = 0.0;
 var master_av2 = 0.0;
 
 var pfd_display = 0.0;
+var pfd_load_ess = 0.0;
+var pfd_load_avn = 0.0;
 
 var stby_batt_breaker = 0.0;
 
@@ -612,15 +614,11 @@ var avionics_bus_1 = func() {
         setprop("/systems/electrical/outputs/pfd-avn", bus_volts);
         if (pfd_avn and (bus_volts > 0)) {
             load += ((getprop("/controls/lighting/avionics-norm/")+5) * pfd_avn) * bus_volts;
-            setprop("/systems/electrical/outputs/fg1000-pfd", 1);
-        } else {
-            setprop("/systems/electrical/outputs/fg1000-pfd", 0);
+            load += pfd_load_avn;
         }
     } else {
         setprop("/systems/electrical/outputs/pfd-avn", 0.0);
-        fg1000system.hide(1);
     }
-    pfd_display = bus_volts;
 
     # Air Data Computer
     if ( getprop("/controls/circuit-breakers/adc-ahrs-avn") ) {
@@ -773,13 +771,10 @@ var essential_bus = func() {
         setprop("/systems/electrical/outputs/pfd-ess", bus_volts);
         if (pfd_ess and (bus_volts > 0)){
             load += ((getprop("/controls/lighting/avionics-norm/")+5) * pfd_ess) * bus_volts;
-            setprop("/systems/electrical/outputs/fg1000-pfd", 1);
-        } else {
-            setprop("/systems/electrical/outputs/fg1000-pfd", 0);
+            load += pfd_load_ess;
         }
     } else {
         setprop("/systems/electrical/outputs/pfd-ess", 0.0);
-        fg1000system.hide(1);
     }
 
     # Air Data Computer
@@ -898,6 +893,26 @@ var toggle_fg1000_MFD = func {
 };
 
 # Switch the FG1000 on/off depending on power.
+# The PFD can be powered by either the AVN1 bus (normal operation)
+# or the essentials bus (in case of electrical failure).
+# The MFD is powered normally trough its bus.
+var fg1000_MFD_calc_power = func() {
+    var amps_load_factor = 4.5;   # 4.5-5 amps
+    var avn_power = getprop("/systems/electrical/outputs/pfd-avn") or 0;
+    var ess_power = getprop("/systems/electrical/outputs/pfd-ess") or 0;
+    var pfd_power = avn_power;
+    pfd_load_avn  = avn_power * amps_load_factor;
+    pfd_load_ess  = 0.0;
+    if (ess_power > avn_power)  {
+        pfd_power = ess_power;
+        pfd_load_avn = 0.0;
+        pfd_load_ess = pfd_power * amps_load_factor;
+    }
+    setprop("/systems/electrical/outputs/fg1000-pfd", pfd_power);
+    pfd_display = pfd_power;
+}
+setlistener("/systems/electrical/outputs/pfd-avn", fg1000_MFD_calc_power, 1, 0);
+setlistener("/systems/electrical/outputs/pfd-ess", fg1000_MFD_calc_power, 1, 0);
 setlistener("/systems/electrical/outputs/fg1000-pfd", func(n) {
     if (n.getValue() > 0) {
       fg1000system.show(1);

--- a/c172p-fg1000-gfc-set.xml
+++ b/c172p-fg1000-gfc-set.xml
@@ -151,7 +151,7 @@ model, instrument panel, and external 3D model.
             <stby-batt type="int">1</stby-batt>
         </switches>
         <lighting>
-            <batt-test-lamp-norm type="int">0</batt-test-lamp-norm>
+            <batt-test-lamp-norm type="double">0</batt-test-lamp-norm>
             <avionics-norm type="double">0</avionics-norm>
             <pedestal-norm type="double">0</pedestal-norm>
             <swcb-norm type="double">0</swcb-norm>

--- a/c172p-fg1000-kap-set.xml
+++ b/c172p-fg1000-kap-set.xml
@@ -121,7 +121,7 @@ model, instrument panel, and external 3D model.
             <stby-batt type="int">1</stby-batt>
         </switches>
         <lighting>
-            <batt-test-lamp-norm type="int">0</batt-test-lamp-norm>
+            <batt-test-lamp-norm type="double">0</batt-test-lamp-norm>
             <avionics-norm type="double">0</avionics-norm>
             <pedestal-norm type="double">0</pedestal-norm>
             <swcb-norm type="double">0</swcb-norm>


### PR DESCRIPTION
Digged a little further into the C172SP FG1000 electrical system and fond two issues:

- [x] The STBY BAT TEST switch
  - [x] changed drag direction to a more natural vertical setting
  - [x] spring loaded TST position properly (more simpler) implemented trough xml
  - [x] test lamp should indicate battery state. Its not an ammeter (like it is wrongly implemented now)
- [x] PFD wiring corrected re AVN and ESS busses
  It was solely calculated from the ESS bus code; ie. if the ESS breaker was pulled, the PFD went dark, even when there was power from the AVN bus.