### PR TITLE
Add ALT mode to Throttle/Mixture levers and trim wheels

### DIFF
--- a/Models/Interior/Panel/c172p-panel/c172p.xml
+++ b/Models/Interior/Panel/c172p-panel/c172p.xml
@@ -2181,9 +2181,23 @@
         </center>
         <action>
             <binding>
+                <condition>
+                    <not><property>/devices/status/keyboard/alt</property></not>
+                </condition>
                 <command>property-adjust</command>
                 <property>controls/flight/elevator-trim</property>
                 <factor>0.001</factor>
+                <min>-1</min>
+                <max>1</max>
+                <wrap>0</wrap>
+            </binding>
+            <binding>
+                <condition>
+                    <property>/devices/status/keyboard/alt</property>
+                </condition>
+                <command>property-adjust</command>
+                <property>controls/flight/elevator-trim</property>
+                <factor>0.0001</factor>
                 <min>-1</min>
                 <max>1</max>
                 <wrap>0</wrap>
@@ -2234,9 +2248,23 @@
         </axis>
         <action>
             <binding>
+                <condition>
+                    <not><property>/devices/status/keyboard/alt</property></not>
+                </condition>
                 <command>property-adjust</command>
                 <property>controls/flight/rudder-trim</property>
                 <factor>0.002</factor>
+                <min>-.18</min>
+                <max>.18</max>
+                <wrap>false</wrap>
+            </binding>
+            <binding>
+                <condition>
+                    <property>/devices/status/keyboard/alt</property>
+                </condition>
+                <command>property-adjust</command>
+                <property>controls/flight/rudder-trim</property>
+                <factor>0.001</factor>
                 <min>-.18</min>
                 <max>.18</max>
                 <wrap>false</wrap>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -2710,11 +2710,26 @@
         <visible>true</visible>
         <drag-direction>vertical</drag-direction>
         <!-- no translation, we handle that seperately -->
+        <shift-repeat>10</shift-repeat>
         <action>
             <binding>
+                <condition>
+                    <not><property>/devices/status/keyboard/alt</property></not>
+                </condition>
                 <command>property-adjust</command>
                 <property>controls/engines/current-engine/throttle</property>
                 <factor>0.02</factor>
+                <min>0</min>
+                <max>1</max>
+                <wrap>0</wrap>
+            </binding>
+            <binding>
+                <condition>
+                    <property>/devices/status/keyboard/alt</property>
+                </condition>
+                <command>property-adjust</command>
+                <property>controls/engines/current-engine/throttle</property>
+                <factor>0.01</factor>
                 <min>0</min>
                 <max>1</max>
                 <wrap>0</wrap>
@@ -2781,11 +2796,26 @@
         <visible>true</visible>
         <!-- no translation, we handle that seperately -->
         <drag-direction>vertical</drag-direction>
+        <shift-repeat>10</shift-repeat>
         <action>
             <binding>
+                <condition>
+                    <not><property>/devices/status/keyboard/alt</property></not>
+                </condition>
                 <command>property-adjust</command>
                 <property>controls/engines/current-engine/mixture</property>
                 <factor>0.02</factor>
+                <min>0</min>
+                <max>1</max>
+                <wrap>0</wrap>
+            </binding>
+            <binding>
+                <condition>
+                    <property>/devices/status/keyboard/alt</property>
+                </condition>
+                <command>property-adjust</command>
+                <property>controls/engines/current-engine/mixture</property>
+                <factor>0.01</factor>
                 <min>0</min>
                 <max>1</max>
                 <wrap>0</wrap>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -2710,7 +2710,7 @@
         <visible>true</visible>
         <drag-direction>vertical</drag-direction>
         <!-- no translation, we handle that seperately -->
-        <shift-repeat>10</shift-repeat>
+        <shift-repeat>2</shift-repeat>
         <action>
             <binding>
                 <condition>
@@ -2718,7 +2718,7 @@
                 </condition>
                 <command>property-adjust</command>
                 <property>controls/engines/current-engine/throttle</property>
-                <factor>0.02</factor>
+                <factor>0.05</factor>
                 <min>0</min>
                 <max>1</max>
                 <wrap>0</wrap>
@@ -2796,7 +2796,7 @@
         <visible>true</visible>
         <!-- no translation, we handle that seperately -->
         <drag-direction>vertical</drag-direction>
-        <shift-repeat>10</shift-repeat>
+        <shift-repeat>2</shift-repeat>
         <action>
             <binding>
                 <condition>
@@ -2804,7 +2804,7 @@
                 </condition>
                 <command>property-adjust</command>
                 <property>controls/engines/current-engine/mixture</property>
-                <factor>0.02</factor>
+                <factor>0.05</factor>
                 <min>0</min>
                 <max>1</max>
                 <wrap>0</wrap>


### PR DESCRIPTION
Pressing ALT and moving the levers (mousewheel/dragging) gives finer control now.
This simulates throttles friction lock and the mixtures vernier feature.