### PR TITLE
KR87 ADF: prevent overflow, implement countdown timer and directly setting the active FRQ in FLT/ELT mode

### DIFF
--- a/Models/Interior/Panel/Instruments/kr87-adf/kr87.xml
+++ b/Models/Interior/Panel/Instruments/kr87-adf/kr87.xml
@@ -70,10 +70,31 @@
         <type>select</type>
         <object-name>indicator.ET</object-name>
         <condition>
-            <equals>
-                <property>instrumentation/adf[0]/display-mode</property>
-                <value type="int">2</value>
-            </equals>
+            <or>
+                <and>
+                    <not><property>instrumentation/adf[0]/set-mode</property></not>
+                    <equals>
+                        <property>instrumentation/adf[0]/display-mode</property>
+                        <value type="int">2</value>
+                    </equals>
+                </and>
+
+                <and>
+                    <property>instrumentation/adf[0]/set-mode</property>
+                    <less-than>
+                        <expression>
+                            <mod>
+                                <product>
+                                    <property>sim/time/elapsed-sec</property>
+                                    <value>10</value>
+                                </product>
+                                <value>10</value>
+                            </mod>
+                        </expression>
+                        <value>4</value>
+                    </less-than>
+                </and>
+            </or>
         </condition>
     </animation>
 
@@ -144,10 +165,36 @@
     <!-- STBY FREQ -->
     <animation>
         <condition>
-            <not-equals>
-                <property>instrumentation/adf[0]/display-mode</property>
-                <value type="int">0</value>
-            </not-equals>
+            <or>
+                <equals>
+                    <property>instrumentation/adf[0]/display-mode</property>
+                    <value type="int">1</value>
+                </equals>
+                <and>
+                    <equals>
+                        <property>instrumentation/adf[0]/display-mode</property>
+                        <value type="int">2</value>
+                    </equals>
+                    <or>
+                        <not><property>instrumentation/adf[0]/enroute-timer/alarm-flash</property></not>
+                        <and>
+                            <property>instrumentation/adf[0]/enroute-timer/alarm-flash</property>
+                            <less-than>
+                                <expression>
+                                    <mod>
+                                        <product>
+                                            <property>sim/time/elapsed-sec</property>
+                                            <value>10</value>
+                                        </product>
+                                        <value>10</value>
+                                    </mod>
+                                </expression>
+                                <value>5</value>
+                            </less-than>
+                        </and>
+                    </or>
+                </and>
+            </or>
         </condition>
         <type>select</type>
         <object-name>indicator.dots</object-name>
@@ -157,10 +204,88 @@
         <type>select</type>
         <object-name>indicator.Stby.1000</object-name>
         <condition>
-            <greater-than-equals>
-                <property alias="../../../../params/right-display"/>
-                <value type="int">1000</value>
-            </greater-than-equals>
+            <or>
+                <and>
+                    <equals>
+                        <property>instrumentation/adf[0]/display-mode</property>
+                        <value type="int">0</value>
+                    </equals>
+                    <greater-than-equals>
+                        <property alias="../../../../../../params/right-display"/>
+                        <value type="int">1000</value>
+                    </greater-than-equals>
+                </and>
+                <equals>
+                    <property>instrumentation/adf[0]/display-mode</property>
+                    <value type="int">1</value>
+                </equals>
+                <and>
+                    <equals>
+                        <property>instrumentation/adf[0]/display-mode</property>
+                        <value type="int">2</value>
+                    </equals>
+                    <or>
+                        <not><property>instrumentation/adf[0]/enroute-timer/alarm-flash</property></not>
+                        <and>
+                            <property>instrumentation/adf[0]/enroute-timer/alarm-flash</property>
+                            <less-than>
+                                <expression>
+                                    <mod>
+                                        <product>
+                                            <property>sim/time/elapsed-sec</property>
+                                            <value>10</value>
+                                        </product>
+                                        <value>10</value>
+                                    </mod>
+                                </expression>
+                                <value>5</value>
+                            </less-than>
+                        </and>
+                    </or>
+                </and>
+            </or>
+        </condition>
+    </animation>
+    <animation>
+        <type>select</type>
+        <object-name>indicator.Stby.100</object-name>
+        <object-name>indicator.Stby.10</object-name>
+        <object-name>indicator.Stby.1</object-name>
+        <condition>
+            <or>
+                <equals>
+                    <property>instrumentation/adf[0]/display-mode</property>
+                    <value type="int">0</value>
+                </equals>
+                <equals>
+                    <property>instrumentation/adf[0]/display-mode</property>
+                    <value type="int">1</value>
+                </equals>
+                <and>
+                    <equals>
+                        <property>instrumentation/adf[0]/display-mode</property>
+                        <value type="int">2</value>
+                    </equals>
+                    <or>
+                        <not><property>instrumentation/adf[0]/enroute-timer/alarm-flash</property></not>
+                        <and>
+                            <property>instrumentation/adf[0]/enroute-timer/alarm-flash</property>
+                            <less-than>
+                                <expression>
+                                    <mod>
+                                        <product>
+                                            <property>sim/time/elapsed-sec</property>
+                                            <value>10</value>
+                                        </product>
+                                        <value>10</value>
+                                    </mod>
+                                </expression>
+                                <value>5</value>
+                            </less-than>
+                        </and>
+                    </or>
+                </and>
+            </or>
         </condition>
     </animation>
 
@@ -314,6 +439,9 @@
         <action>
             <button>0</button>
             <binding>
+                <condition>
+                    <not><property>instrumentation/adf[0]/set-mode</property></not>
+                </condition>
                 <command>property-toggle</command>
                 <property>instrumentation/adf[0]/bfo-frq</property>
             </binding>
@@ -324,16 +452,22 @@
             </binding>
             <binding>
                 <condition>
-                    <equals>
-                        <property>instrumentation/adf[0]/display-mode</property>
-                        <value type="int">0</value>
-                    </equals>
+                    <and>
+                        <not><property>instrumentation/adf[0]/set-mode</property></not>
+                        <equals>
+                            <property>instrumentation/adf[0]/display-mode</property>
+                            <value type="int">0</value>
+                        </equals>
+                    </and>
                 </condition>
                 <command>property-swap</command>
                 <property>instrumentation/adf[0]/frequencies/selected-khz</property>
                 <property>instrumentation/adf[0]/frequencies/standby-khz</property>
             </binding>
             <binding>
+                <condition>
+                    <not><property>instrumentation/adf[0]/set-mode</property></not>
+                </condition>
                 <command>property-assign</command>
                 <property>instrumentation/adf[0]/display-mode</property>
                 <value type="int">0</value>
@@ -387,6 +521,9 @@
                 <value type="int">1</value>
             </binding>
             <binding>
+                <condition>
+                    <not><property>instrumentation/adf[0]/set-mode</property></not>
+                </condition>
                 <command>property-adjust</command>
                 <property>instrumentation/adf[0]/display-mode</property>
                 <step>1</step>
@@ -441,6 +578,11 @@
                 <command>property-assign</command>
                 <property>instrumentation/adf[0]/set-btn</property>
                 <value type="int">1</value>
+            </binding>
+            <binding>
+                <command>property-assign</command>
+                <property>instrumentation/adf[0]/set-btn-presstime</property>
+                <property>sim/time/elapsed-sec</property>
             </binding>
             <binding>
                 <command>nasal</command>
@@ -552,10 +694,13 @@
             <binding>
                 <!-- store current value for overflow comparison -->
                 <condition>
-                    <equals>
-                        <property>instrumentation/adf[0]/display-mode</property>
-                        <value type="int">0</value>
-                    </equals>
+                    <and>
+                        <not><property>instrumentation/adf[0]/set-mode</property></not>
+                        <equals>
+                            <property>instrumentation/adf[0]/display-mode</property>
+                            <value type="int">0</value>
+                        </equals>
+                    </and>
                 </condition>
                 <command>property-assign</command>
                 <property>instrumentation/adf[0]/frequencies/overflow-khz</property>
@@ -563,10 +708,13 @@
             </binding>
             <binding>
                 <condition>
-                    <equals>
-                        <property>instrumentation/adf[0]/display-mode</property>
-                        <value type="int">0</value>
-                    </equals>
+                    <and>
+                        <not><property>instrumentation/adf[0]/set-mode</property></not>
+                        <equals>
+                            <property>instrumentation/adf[0]/display-mode</property>
+                            <value type="int">0</value>
+                        </equals>
+                    </and>
                 </condition>
                 <command>property-adjust</command>
                 <property>instrumentation/adf[0]/frequencies/standby-khz</property>
@@ -579,10 +727,13 @@
             <binding>
                 <!-- on increase/decrease: detect and prevent overflow -->
                 <condition>
-                    <equals>
-                        <property>instrumentation/adf[0]/display-mode</property>
-                        <value type="int">0</value>
-                    </equals>
+                    <and>
+                        <not><property>instrumentation/adf[0]/set-mode</property></not>
+                        <equals>
+                            <property>instrumentation/adf[0]/display-mode</property>
+                            <value type="int">0</value>
+                        </equals>
+                    </and>
                 </condition>
                 <command>nasal</command>
                 <script><![CDATA[
@@ -597,10 +748,13 @@
             <binding>
                 <!-- store current value for overflow comparison -->
                 <condition>
-                    <greater-than-equals>
-                        <property>instrumentation/adf[0]/display-mode</property>
-                        <value type="int">0</value>
-                    </greater-than-equals>
+                    <and>
+                        <not><property>instrumentation/adf[0]/set-mode</property></not>
+                        <greater-than-equals>
+                            <property>instrumentation/adf[0]/display-mode</property>
+                            <value type="int">0</value>
+                        </greater-than-equals>
+                    </and>
                 </condition>
                 <command>property-assign</command>
                 <property>instrumentation/adf[0]/frequencies/overflow-khz</property>
@@ -608,10 +762,13 @@
             </binding>
             <binding>
                 <condition>
-                    <greater-than-equals>
-                        <property>instrumentation/adf[0]/display-mode</property>
-                        <value type="int">1</value>
-                    </greater-than-equals>
+                    <and>
+                        <not><property>instrumentation/adf[0]/set-mode</property></not>
+                        <greater-than-equals>
+                            <property>instrumentation/adf[0]/display-mode</property>
+                            <value type="int">1</value>
+                        </greater-than-equals>
+                    </and>
                 </condition>
                 <command>property-adjust</command>
                 <property>instrumentation/adf[0]/frequencies/selected-khz</property>
@@ -624,10 +781,13 @@
             <binding>
                 <!-- on increase/decrease: detect and prevent overflow -->
                 <condition>
-                    <greater-than-equals>
-                        <property>instrumentation/adf[0]/display-mode</property>
-                        <value type="int">1</value>
-                    </greater-than-equals>
+                    <and>
+                        <not><property>instrumentation/adf[0]/set-mode</property></not>
+                        <greater-than-equals>
+                            <property>instrumentation/adf[0]/display-mode</property>
+                            <value type="int">1</value>
+                        </greater-than-equals>
+                    </and>
                 </condition>
                 <command>nasal</command>
                 <script><![CDATA[
@@ -637,6 +797,26 @@
                     if (diff != 0) setprop("instrumentation/adf[0]/frequencies/selected-khz", newFRQ + diff*100)
                 ]]></script>
            </binding>
+
+           <!-- ET set mode -->
+           <binding>
+                <condition>
+                    <and>
+                        <property>instrumentation/adf[0]/set-mode</property>
+                        <equals>
+                            <property>instrumentation/adf[0]/display-mode</property>
+                            <value type="int">2</value>
+                        </equals>
+                    </and>
+                </condition>
+                <command>property-adjust</command>
+                <property>instrumentation/adf[0]/enroute-timer/time</property>
+                <factor>1</factor>
+                <resolution>1</resolution>
+                <wrap>false</wrap>
+                <min>0</min>
+                <max>3599</max>
+            </binding>
 
             <binding>
                 <command>property-adjust</command>
@@ -678,12 +858,16 @@
             <z-m>-0.01618</z-m>
         </center>
         <action>
+            <!-- Normal mode -->
             <binding>
                 <condition>
-                    <equals>
-                        <property>instrumentation/adf[0]/display-mode</property>
-                        <value type="int">0</value>
-                    </equals>
+                    <and>
+                        <not><property>instrumentation/adf[0]/set-mode</property></not>
+                        <equals>
+                            <property>instrumentation/adf[0]/display-mode</property>
+                            <value type="int">0</value>
+                        </equals>
+                    </and>
                 </condition>
                 <command>property-adjust</command>
                 <property>instrumentation/adf[0]/frequencies/standby-khz</property>
@@ -693,12 +877,17 @@
                 <resolution>1</resolution>
                 <wrap>true</wrap>
             </binding>
+
+            <!-- FT/ET mode -->
             <binding>
                 <condition>
-                    <greater-than-equals>
-                        <property>instrumentation/adf[0]/display-mode</property>
-                        <value type="int">1</value>
-                    </greater-than-equals>
+                    <and>
+                        <not><property>instrumentation/adf[0]/set-mode</property></not>
+                        <greater-than-equals>
+                            <property>instrumentation/adf[0]/display-mode</property>
+                            <value type="int">1</value>
+                        </greater-than-equals>
+                    </and>
                 </condition>
                 <command>property-adjust</command>
                 <property>instrumentation/adf[0]/frequencies/selected-khz</property>
@@ -708,6 +897,27 @@
                 <resolution>1</resolution>
                 <wrap>true</wrap>
             </binding>
+
+            <!-- ET set mode -->
+            <binding>
+                <condition>
+                    <and>
+                        <property>instrumentation/adf[0]/set-mode</property>
+                        <equals>
+                            <property>instrumentation/adf[0]/display-mode</property>
+                            <value type="int">2</value>
+                        </equals>
+                    </and>
+                </condition>
+                <command>property-adjust</command>
+                <property>instrumentation/adf[0]/enroute-timer/time</property>
+                <factor>60</factor>
+                <resolution>1</resolution>
+                <wrap>false</wrap>
+                <min>0</min>
+                <max>3599</max>
+            </binding>
+
             <binding>
                 <command>property-adjust</command>
                 <property alias="/params/dial-100-khz"/>

--- a/Models/Interior/Panel/Instruments/kr87-adf/kr87.xml
+++ b/Models/Interior/Panel/Instruments/kr87-adf/kr87.xml
@@ -548,7 +548,26 @@
             <z-m>-0.01618</z-m>
         </center>
         <action>
+            <!-- Normal mode -->
             <binding>
+                <!-- store current value for overflow comparison -->
+                <condition>
+                    <equals>
+                        <property>instrumentation/adf[0]/display-mode</property>
+                        <value type="int">0</value>
+                    </equals>
+                </condition>
+                <command>property-assign</command>
+                <property>instrumentation/adf[0]/frequencies/overflow-khz</property>
+                <property>instrumentation/adf[0]/frequencies/standby-khz</property>
+            </binding>
+            <binding>
+                <condition>
+                    <equals>
+                        <property>instrumentation/adf[0]/display-mode</property>
+                        <value type="int">0</value>
+                    </equals>
+                </condition>
                 <command>property-adjust</command>
                 <property>instrumentation/adf[0]/frequencies/standby-khz</property>
                 <factor>1</factor>
@@ -557,6 +576,68 @@
                 <resolution>1</resolution>
                 <wrap>true</wrap>
             </binding>
+            <binding>
+                <!-- on increase/decrease: detect and prevent overflow -->
+                <condition>
+                    <equals>
+                        <property>instrumentation/adf[0]/display-mode</property>
+                        <value type="int">0</value>
+                    </equals>
+                </condition>
+                <command>nasal</command>
+                <script><![CDATA[
+                    var oldFRQ = getprop("instrumentation/adf[0]/frequencies/overflow-khz");
+                    var newFRQ = getprop("instrumentation/adf[0]/frequencies/standby-khz");
+                    var diff = math.floor(oldFRQ/100) - math.floor(newFRQ/100);
+                    if (diff != 0) setprop("instrumentation/adf[0]/frequencies/standby-khz", newFRQ + diff*100)
+                ]]></script>
+           </binding>
+
+            <!-- FLT/ELT timer mode -->
+            <binding>
+                <!-- store current value for overflow comparison -->
+                <condition>
+                    <greater-than-equals>
+                        <property>instrumentation/adf[0]/display-mode</property>
+                        <value type="int">0</value>
+                    </greater-than-equals>
+                </condition>
+                <command>property-assign</command>
+                <property>instrumentation/adf[0]/frequencies/overflow-khz</property>
+                <property>instrumentation/adf[0]/frequencies/selected-khz</property>
+            </binding>
+            <binding>
+                <condition>
+                    <greater-than-equals>
+                        <property>instrumentation/adf[0]/display-mode</property>
+                        <value type="int">1</value>
+                    </greater-than-equals>
+                </condition>
+                <command>property-adjust</command>
+                <property>instrumentation/adf[0]/frequencies/selected-khz</property>
+                <factor>1</factor>
+                <min>200</min>
+                <max>1800</max>
+                <resolution>1</resolution>
+                <wrap>true</wrap>
+            </binding>
+            <binding>
+                <!-- on increase/decrease: detect and prevent overflow -->
+                <condition>
+                    <greater-than-equals>
+                        <property>instrumentation/adf[0]/display-mode</property>
+                        <value type="int">1</value>
+                    </greater-than-equals>
+                </condition>
+                <command>nasal</command>
+                <script><![CDATA[
+                    var oldFRQ = getprop("instrumentation/adf[0]/frequencies/overflow-khz");
+                    var newFRQ = getprop("instrumentation/adf[0]/frequencies/selected-khz");
+                    var diff = math.floor(oldFRQ/100) - math.floor(newFRQ/100);
+                    if (diff != 0) setprop("instrumentation/adf[0]/frequencies/selected-khz", newFRQ + diff*100)
+                ]]></script>
+           </binding>
+
             <binding>
                 <command>property-adjust</command>
                 <property alias="/params/dial-1-khz"/>
@@ -570,6 +651,7 @@
                 <script>c172p.click("kr87-adf-dial")</script>
             </binding>
         </action>
+
         <hovered>
             <binding>
                 <command>set-tooltip</command>
@@ -597,8 +679,29 @@
         </center>
         <action>
             <binding>
+                <condition>
+                    <equals>
+                        <property>instrumentation/adf[0]/display-mode</property>
+                        <value type="int">0</value>
+                    </equals>
+                </condition>
                 <command>property-adjust</command>
                 <property>instrumentation/adf[0]/frequencies/standby-khz</property>
+                <factor>100</factor>
+                <min>200</min>
+                <max>1800</max>
+                <resolution>1</resolution>
+                <wrap>true</wrap>
+            </binding>
+            <binding>
+                <condition>
+                    <greater-than-equals>
+                        <property>instrumentation/adf[0]/display-mode</property>
+                        <value type="int">1</value>
+                    </greater-than-equals>
+                </condition>
+                <command>property-adjust</command>
+                <property>instrumentation/adf[0]/frequencies/selected-khz</property>
                 <factor>100</factor>
                 <min>200</min>
                 <max>1800</max>

--- a/Nasal/kr87.nas
+++ b/Nasal/kr87.nas
@@ -93,6 +93,7 @@ var kr87 = {
         m.powerButtonN.setBoolValue( m.powerButtonN.getValue() );
         m.adfButtonN = m.baseN.initNode( "adf-btn", 0, "BOOL" );
         m.bfoButtonN = m.baseN.initNode( "bfo-btn", 0, "BOOL" );
+        m.operable = m.baseN.initNode( "operable", 0, "BOOL" );
 
         m.modeN = m.baseN.getNode( "mode" );
         aircraft.data.add(
@@ -172,12 +173,29 @@ var kr87 = {
             me.flt.restart();
             me.displayModeN.setIntValue( 0 );
         }
+
         me.power = me.powerButtonN.getValue();
+
+        if (!me.operable.getBoolValue() ) {
+            # powerloss or failure: reset and stop timers
+            me.et.stop();
+            me.et.reset();
+            me.flt.stop();
+            me.flt.reset();
+            me.displayModeN.setIntValue( 0 );
+        } else {
+            # power recovery
+            if (!me.flt.runningN.getValue())
+                me.flt.start();
+            if (!me.et.runningN.getValue())
+                me.et.start();
+        }
 
         settimer( func { me.update() }, 0.1 );
     }
 };
 
-var kr87_0 = kr87.new( "/instrumentation/adf[0]" ).update();
 
-#setlistener("/sim/signals/fdm-initialized", func { timer_update() } );
+setlistener("/sim/signals/fdm-initialized", func {
+    kr87.new( "/instrumentation/adf[0]" ).update();
+} );

--- a/Nasal/kr87.nas
+++ b/Nasal/kr87.nas
@@ -16,7 +16,19 @@ var timer = {
 
         m.timeN = m.baseN.initNode( "time", 0.0 );
         m.runningN = m.baseN.initNode( "running", 0, "BOOL" );
-        m.startTimeN = m.baseN.initNode( "start-time", -1.0 );
+        m.stepFactor = m.baseN.initNode( "step-factor", 1 ); # count up by default
+        
+        m.clock = maketimer(1, func(){
+            m.timeN.setValue(m.timeN.getValue() + m.stepFactor.getValue());
+        });
+        m.clock.simulatedTime = 1;
+        setlistener( m.runningN, func(n) {
+            if (n.getValue()) {
+                m.clock.start();
+            } else {
+                m.clock.stop();
+            }
+        } );
 
         return m;
     },
@@ -27,15 +39,17 @@ var timer = {
 
     start : func { 
        me.runningN.setBoolValue( 1 );
+       me.clock.start();
     },
 
     stop : func { 
        me.runningN.setBoolValue( 0 ); 
+       me.clock.stop();
     },
 
     reset : func {
-        me.startTimeN.setDoubleValue( elapsedTimeSecN.getValue() );
         me.timeN.setDoubleValue( 0 );
+        me.stepFactor.setValue(1);
     },
 
     restart : func {
@@ -54,12 +68,6 @@ var timer = {
         return h * 10000 + m * 100 + s;
     },
 
-    update : func {
-        if( me.runningN.getValue() ) {
-            me.timeN.setDoubleValue( elapsedTimeSecN.getValue() - me.startTimeN.getValue() );
-        }
-      }
-
 };
 
 ####################################################################
@@ -75,6 +83,8 @@ var kr87 = {
         m.flt.restart();
         m.et  = timer.new( m.base ~ "/enroute-timer" );
         m.et.restart();
+        m.et_alarmFlash = m.baseN.initNode( "enroute-timer/alarm-flash", 0, "BOOL" );
+        m.et_alarmSound = m.baseN.initNode( "enroute-timer/alarm-sound", 0, "BOOL" );
 
         m.displayModeN = m.baseN.initNode( "display-mode", 0, "INT" );
 
@@ -90,10 +100,14 @@ var kr87 = {
         m.powerButtonN = m.baseN.initNode( "power-btn", 0, "BOOL" ); 
         m.powerButtonN.setBoolValue( m.volumeNormN.getValue() != 0 );
         m.setButtonN = m.baseN.initNode( "set-btn", 0, "BOOL" );
+        m.setButtonPTN = m.baseN.initNode( "set-btn-presstime", 0, "DOUBLE" );
         m.powerButtonN.setBoolValue( m.powerButtonN.getValue() );
         m.adfButtonN = m.baseN.initNode( "adf-btn", 0, "BOOL" );
         m.bfoButtonN = m.baseN.initNode( "bfo-btn", 0, "BOOL" );
         m.operable = m.baseN.initNode( "operable", 0, "BOOL" );
+        m.isOperable = 0;
+
+        m.setModeN = m.baseN.initNode( "set-mode", 0, "BOOL" );
 
         m.modeN = m.baseN.getNode( "mode" );
         aircraft.data.add(
@@ -129,19 +143,30 @@ var kr87 = {
             me.et.restart();
             me.flt.restart();
             me.displayModeN.setIntValue( 0 );
+            me.setModeN.setBoolValue(0);
           }
         me.power = me.powerButtonN.getValue();
     },
 
     update : func {
-        me.flt.update();
-        me.et.update(); 
         var m = me.displayModeN.getValue();
 
         if( m == 0 ) {
             # FRQ
             me.rightDisplayN.setIntValue( me.standbyFrequencyN.getValue() );
         } 
+
+        # Handle count-down wrapping;
+        # this happens when the countdown reaches zero.
+        # We flash the alarm and switch to the ET mode; clock starts to count upwards.
+        if (me.et.clock.isRunning and me.et.stepFactor.getValue() < 0 and me.et.getTime() <= 0) {
+            me.et.restart();
+            me.et_alarmFlash.setBoolValue(1);
+            me.et_alarmSound.setBoolValue(1);
+            me.displayModeN.setIntValue(2);
+            settimer( func { me.et_alarmFlash.setBoolValue(0); }, 15 );
+            settimer( func { me.et_alarmSound.setBoolValue(0); }, 1 );
+        }
 
         # the display works up to 99h, 59m, 59s and then
         # displays 00:00 again. Don't know if this is the like the true kr87
@@ -163,15 +188,38 @@ var kr87 = {
             me.rightDisplayN.setIntValue( t );
         }
 
-        if( me.setButtonN.getValue() ) {
-           me.et.restart();
+        var setButtonPTN_td = 0;
+        if (me.setButtonPTN.getValue() > 0.0)  setButtonPTN_td = elapsedTimeSecN.getValue() - me.setButtonPTN.getValue();
+        if( !me.setButtonN.getValue() and setButtonPTN_td >= 0.1 and setButtonPTN_td < 2.0) {
+           # set-button was released before 2 secs
+           me.setButtonPTN.setValue(0);
+           if (me.et.clock.isRunning) {
+               # counter is running; restart
+               me.et.restart();
+           }
+           if (me.setModeN.getValue() and !me.et.clock.isRunning) {
+               # set mode was active, start count down as timer was not running
+               me.setModeN.setBoolValue(0);
+               me.et.start();
+           }
         }
+        if( me.setButtonN.getValue() and setButtonPTN_td >= 2.0) {
+            # set-button is still hold after 2 secs in ET mode: enter set-mode
+            me.displayModeN.setIntValue(2);
+            me.setModeN.setBoolValue(1);
+            me.et.stop();
+            # me.et.reset();   <-unsure, if the set mode starts at the current setting or at 00:00
+            me.et.stepFactor.setValue(-1); # arm count-down mode
+        }
+        if( me.setButtonN.getValue() )  me.et_alarmFlash.setBoolValue(0); # in case we had an alarm active
+        if( me.setButtonN.getValue() )  me.et_alarmSound.setBoolValue(0); # in case we had an alarm active
 
         if( me.powerButtonN.getBoolValue() and !me.power ) {
             # power on, restart timer and start with FRQ display
             me.et.restart();
             me.flt.restart();
             me.displayModeN.setIntValue( 0 );
+            me.setModeN.setBoolValue(0);
         }
 
         me.power = me.powerButtonN.getValue();
@@ -180,16 +228,22 @@ var kr87 = {
             # powerloss or failure: reset and stop timers
             me.et.stop();
             me.et.reset();
+            me.et.reset();
             me.flt.stop();
             me.flt.reset();
             me.displayModeN.setIntValue( 0 );
+            me.setModeN.setBoolValue(0);
         } else {
             # power recovery
-            if (!me.flt.runningN.getValue())
-                me.flt.start();
-            if (!me.et.runningN.getValue())
-                me.et.start();
+            if (!me.isOperable) {
+                if (!me.flt.clock.isRunning)
+                    me.flt.start();
+                if (!me.et.clock.isRunning) {
+                    me.et.start();
+                }
+            }
         }
+        me.isOperable = me.operable.getBoolValue();
 
         settimer( func { me.update() }, 0.1 );
     }

--- a/c172-sound.xml
+++ b/c172-sound.xml
@@ -2189,6 +2189,26 @@
             </pitch>
         </AvionicsFan2>
 
+        <kr87-alert>
+            <name>KR87 ET countdown alarm</name>
+            <path>Sounds/beep.wav</path>
+            <mode>once</mode>
+            <condition>
+                <and>
+                    <property>/instrumentation/adf/operable</property>
+                    <property>/instrumentation/adf/enroute-timer/alarm-sound</property>
+                </and>
+            </condition>
+            <volume><factor>0.2</factor></volume>
+            <position>
+                <x-m>0.352</x-m>
+                <y-m>-0.433</y-m>
+                <z-m>0.402</z-m>
+            </position>
+            <reference-dist>0.4</reference-dist>
+            <max-dist>5.0</max-dist>
+        </kr87-alert>
+
     </fx>
 
 </PropertyList>


### PR DESCRIPTION
Fix #1279 

- [x] Fix open things of #1279
- [x] Implement count-down mode of ET timer
  (by this occasion, I rewrote the internal timer implementation to use the much friendlier `maketimer()` interface)