### PR TITLE
Add "X" to aircraft dialog closing buttons (in the window header)

### DIFF
--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -61,10 +61,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c172p-about.xml
+++ b/gui/dialogs/c172p-about.xml
@@ -28,10 +28,11 @@
         </text>
         <empty><stretch>true</stretch></empty>
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c172p-baggage-weight.xml
+++ b/gui/dialogs/c172p-baggage-weight.xml
@@ -18,10 +18,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c172p-fuel-both-tanks.xml
+++ b/gui/dialogs/c172p-fuel-both-tanks.xml
@@ -44,10 +44,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c172p-ground-equipment.xml
+++ b/gui/dialogs/c172p-ground-equipment.xml
@@ -28,10 +28,11 @@
         </text>        
         <empty><stretch>true</stretch></empty>
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c172p-left-fuel-sample.xml
+++ b/gui/dialogs/c172p-left-fuel-sample.xml
@@ -18,10 +18,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c172p-left-fuel.xml
+++ b/gui/dialogs/c172p-left-fuel.xml
@@ -36,10 +36,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>nasal</command>
                 <script>

--- a/gui/dialogs/c172p-mooring-parameters.xml
+++ b/gui/dialogs/c172p-mooring-parameters.xml
@@ -31,10 +31,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c172p-oil-160.xml
+++ b/gui/dialogs/c172p-oil-160.xml
@@ -20,10 +20,11 @@
             <stretch>true</stretch>
         </empty>
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>nasal</command>
                 <script>

--- a/gui/dialogs/c172p-oil-180.xml
+++ b/gui/dialogs/c172p-oil-180.xml
@@ -21,10 +21,11 @@
         </empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>nasal</command>
                 <script>

--- a/gui/dialogs/c172p-right-fuel-sample.xml
+++ b/gui/dialogs/c172p-right-fuel-sample.xml
@@ -18,10 +18,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/c172p-right-fuel.xml
+++ b/gui/dialogs/c172p-right-fuel.xml
@@ -36,11 +36,12 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
-           <binding>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
+            <binding>
                 <command>nasal</command>
                 <script>
                     setprop("sim/model/open-sfuel-cap", 0);

--- a/gui/dialogs/c172p-save.xml
+++ b/gui/dialogs/c172p-save.xml
@@ -14,10 +14,11 @@
         <text><label>Save and Resume</label></text>
         <empty><stretch>true</stretch></empty>
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>

--- a/gui/dialogs/immat.xml
+++ b/gui/dialogs/immat.xml
@@ -18,10 +18,11 @@
         <empty><stretch>true</stretch></empty>
 
         <button>
-            <legend/>
+            <legend>X</legend>
             <key>Esc</key>
-            <pref-width>16</pref-width>
-            <pref-height>16</pref-height>
+            <halign>right</halign>
+            <pref-width>20</pref-width>
+            <pref-height>20</pref-height>
             <binding>
                 <command>dialog-close</command>
             </binding>


### PR DESCRIPTION
This adds a "X" to the dialogs closing button in the top right corner, like Josh recently proposed on the Mailing List.

Fix #1500