### PR TITLE
Starter overheat simulation

### DIFF
--- a/Nasal/electrical-fg1000.nas
+++ b/Nasal/electrical-fg1000.nas
@@ -456,7 +456,10 @@ var update_virtual_bus = func (dt) {
     if (master_bat and (feeder_a or feeder_b)) {
         setprop("/systems/electrical/outputs/instr-ignition-switch", bus_volts);
         if ( bus_volts > 12 ) {
-            if (getprop("controls/switches/starter")) {
+            # starter
+            var starter_svc    = getprop("/engines/active-engine/starter/serviceable");
+            var starter_molten = getprop("/engines/active-engine/starter/overheated");
+            if ( getprop("controls/switches/starter") and starter_svc and !starter_molten ) {
                 setprop("systems/electrical/outputs/starter", bus_volts);
             } else {
                 setprop("systems/electrical/outputs/starter", 0.0);

--- a/Nasal/electrical.nas
+++ b/Nasal/electrical.nas
@@ -389,7 +389,9 @@ var electrical_bus_1 = func() {
         setprop("/systems/electrical/outputs/instr-ignition-switch", bus_volts);
         if ( bus_volts > 12 ) {
             # starter
-            if ( getprop("controls/switches/starter") ) {
+            var starter_svc    = getprop("/engines/active-engine/starter/serviceable");
+            var starter_molten = getprop("/engines/active-engine/starter/overheated");
+            if ( getprop("controls/switches/starter") and starter_svc and !starter_molten ) {
                 setprop("systems/electrical/outputs/starter", bus_volts);
             } else {
                 setprop("systems/electrical/outputs/starter", 0.0);

--- a/Nasal/save.nas
+++ b/Nasal/save.nas
@@ -236,6 +236,9 @@ var save_state = func {
     var digitalclock = getprop("/sim/model/c172p/digitalclock-visible");
     setprop("/save/digitalclock", digitalclock);
 
+    var starter_molten = getprop("/engines/active-engine/starter/overheated");
+    setprop("/save/starter-overheated", starter_molten);
+
     #var userviewx = getprop("/sim/current-view/user/x-offset-m");
     #setprop("/save/userviewx", userviewx);
     #var userviewy = getprop("/sim/current-view/user/y-offset-m");
@@ -702,6 +705,9 @@ var resume_state = func {
 
         var damage = getprop("/save/damage");
         #var altitude = getprop("/save/altitude-ft");
+
+        var starter_molten = getprop("/save/starter-overheated");
+        setprop("/engines/active-engine/starter/overheated", starter_molten);
 
         var heading_delay = 3.0;
         var mooring_delay = 4.0;

--- a/Systems/engine.xml
+++ b/Systems/engine.xml
@@ -937,4 +937,102 @@
         </output>
     </filter>
 
+    <!-- ============================================================== -->
+    <!-- Starter overheating                                            -->
+    <!-- ============================================================== -->
+    <filter>
+        <name>Starter temperature</name>
+        <type>noise-spike</type>
+        <!--<debug>true</debug>-->
+        <enable>
+            <condition>
+                <and>
+                    <property>/engines/active-engine/complex-engine-procedures</property>
+                    <property>/engines/active-engine/starter-management</property>
+                </and>
+            </condition>
+        </enable>
+        <initialize-to>input</initialize-to>
+
+        <!-- Init / repairing: allow temp value to sdrop rapidly -->
+        <max-rate-of-change>
+            <condition>
+                <and>
+                    <not><property>/systems/electrical/outputs/starter</property></not>
+                    <or>
+                        <property>/fdm/jsbsim/damage/repairing</property>
+                        <less-than>
+                            <property>/sim/time/elapsed-sec</property>
+                            <value>5.0</value>
+                        </less-than>
+                    </or>
+                </and>
+            </condition>
+            <expression>
+                <value>250.0</value>
+            </expression>
+        </max-rate-of-change>
+
+        <!-- starter engaged: heat up -->
+        <max-rate-of-change>
+            <condition>
+                <property>/systems/electrical/outputs/starter</property>
+            </condition>
+            <expression>
+                <value>3.5</value> <!-- deg/second -->
+            </expression>
+        </max-rate-of-change>
+        <input>
+            <condition>
+                <property>/systems/electrical/outputs/starter</property>
+            </condition>
+            <value>300</value>
+        </input>
+
+        <!-- starter inactive: cooldown -->
+        <max-rate-of-change>
+            <expression>
+                <value>1.0</value> <!-- deg/second -->
+            </expression>
+        </max-rate-of-change>
+        <input>
+            <expression>
+                <product>
+                    <difference>
+                        <property>/engines/active-engine/cowling-air-temperature-degf</property>
+                        <value>32</value>
+                    </difference>
+                    <value>0.556</value>
+                </product>
+            </expression>
+        </input>
+        <output>/engines/active-engine/starter/temperature-degc</output>
+    </filter>
+    <logic>
+        <name>Starter overheated</name>
+        <input>
+            <and>
+                <property>/engines/active-engine/complex-engine-procedures</property>
+                <property>/engines/active-engine/starter-management</property>
+                <or>
+                    <and> <!-- if it was molten, keep it molten - unless we repair -->
+                        <property>/engines/active-engine/starter/overheated</property>
+                        <not><property>/fdm/jsbsim/damage/repairing</property></not>
+                    </and>
+
+                    <and> <!-- if starter is engaging and exceeding critical temp, melt down -->
+                        <property>systems/electrical/outputs/starter</property>
+                        <greater-than-equals>
+                            <property>/engines/active-engine/starter/temperature-degc</property>
+                            <value>100</value> <!-- critical temp -->
+                        </greater-than-equals>
+                    </and>
+                </or>
+            </and>
+        </input>
+        <output>
+            <property>/engines/active-engine/starter/overheated</property>
+        </output>
+    </logic>
+
 </PropertyList>

--- a/c172p-main.xml
+++ b/c172p-main.xml
@@ -400,6 +400,7 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <path>/systems/electrical/battery-charge-percent</path>
             <path>/sim/model/c172p/save-state</path>
             <path>/engines/active-engine/complex-engine-procedures</path>
+            <path>/engines/active-engine/starter-management</path>
             <path>/sim/model/immat</path>
             <path>/sim/model/hide-yoke-alpha-cmd</path>
             <path>/controls/mooring/automatic</path>
@@ -930,6 +931,10 @@ http://forum.flightgear.org/viewtopic.php?f=4&t=25157
             <complex-engine-procedures type="bool">false</complex-engine-procedures>
             <damage_allowed>false</damage_allowed>
             <winter-kit-installed type="int">0</winter-kit-installed>
+            <starter-management type="bool">false</starter-management>
+            <starter>
+                <serviceable type="bool">true</serviceable>
+            </starter>
         </active-engine>
 
         <!-- Following properties are part of a static list of properties

--- a/gui/dialogs/aircraft-dialog.xml
+++ b/gui/dialogs/aircraft-dialog.xml
@@ -117,6 +117,33 @@
                     <command>dialog-apply</command>
                 </binding>
             </checkbox>
+            <group>
+                <layout>hbox</layout>
+                <halign>left</halign>
+                <!-- Small left padding -->
+                <group>
+                    <layout>vbox</layout>
+                    <padding>12</padding>
+                </group>
+                <group>
+                    <layout>vbox</layout>
+                    <checkbox>
+                        <halign>left</halign>
+                        <label>Allow starter cycle limits</label>
+                        <property>/engines/active-engine/starter-management</property>
+                        <live>true</live>
+                        <enable>
+                            <and>
+                                <property>/engines/active-engine/complex-engine-procedures</property>
+                            </and>
+                        </enable>
+                        <binding>
+                            <command>dialog-apply</command>
+                        </binding>
+                    </checkbox>
+                    <!-- more sub-checkboxes go here -->
+                </group>
+            </group>
 
             <group>
                 <layout>hbox</layout>


### PR DESCRIPTION
Not respecting the starter duty cycle will damage the starter.
Also added a "serviceable" property to the starter, so failure code may hook that up later. 
Starter properties live below '/engines/active-engine/starter'.
The feature can be toggled on in the aircraft options, and is off as default.

![grafik](https://github.com/c172p-team/c172p/assets/13608602/a8179c97-4b19-4dfa-bda7-3a4bdeea6c90)
POH, 4-26

The melt down is also depending on the cowling temperature.
Current simulation melts the starter after about 25 seconds continuous(!) operation with fair weather.
Values are guessed (and probably too strict to teach the pilot proper technique) - I did not found actual numbers; but tuning this later is very easy.