### PR TITLE
Parking brake-lever animation enhanced

### DIFF
--- a/Models/Interior/Panel/c172p-panel/c172p.xml
+++ b/Models/Interior/Panel/c172p-panel/c172p.xml
@@ -1993,8 +1993,13 @@
     <animation>
         <type>rotate</type>
         <object-name>ParkingBrake</object-name>
-        <property alias="/params/controls/parking-lever"/>
-        <factor>90</factor>
+        <expression>
+            <table>
+                <property alias="/params/controls/parking-lever"/>
+                <entry> <ind>0.85</ind> <dep>0.0</dep> </entry>
+                <entry> <ind>1.0</ind> <dep>90</dep> </entry>
+            </table>
+        </expression>
         <axis>
             <x>1.0</x>
             <y>0.0</y>

--- a/Models/Interior/Panel/c172sp-panel/c172sp.xml
+++ b/Models/Interior/Panel/c172sp-panel/c172sp.xml
@@ -1611,8 +1611,13 @@
     <animation>
         <type>rotate</type>
         <object-name>ParkingBrake-fg1000</object-name>
-        <property alias="/params/controls/parking-lever"/>
-        <factor>90</factor>
+        <expression>
+            <table>
+                <property alias="/params/controls/parking-lever"/>
+                <entry> <ind>0.85</ind> <dep>0.0</dep> </entry>
+                <entry> <ind>1.0</ind> <dep>90</dep> </entry>
+            </table>
+        </expression>
         <axis>
             <x>1.0</x>
             <y>0.0</y>

--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -2656,8 +2656,16 @@
         <type>translate</type>
         <object-name>ParkingBrake</object-name>
         <object-name>ParkingBrake-fg1000</object-name>
-        <property alias="/params/controls/parking-lever"/>
-        <factor>0.04</factor>
+        <expression>
+            <table>
+                <property alias="/params/controls/parking-lever"/>
+                <entry> <ind>0.00</ind> <dep>0.00</dep> </entry>
+                <entry> <ind>0.20</ind> <dep>0.02</dep> </entry>
+                <entry> <ind>0.40</ind> <dep>0.03</dep> </entry>
+                <entry> <ind>0.60</ind> <dep>0.035</dep> </entry>
+                <entry> <ind>0.70</ind> <dep>0.04</dep> </entry>
+            </table>
+        </expression>
         <axis>
             <x>1.0</x>
             <y>0.0</y>

--- a/Systems/ground-effects.xml
+++ b/Systems/ground-effects.xml
@@ -482,7 +482,7 @@ Under the GPL. Used by shadows under ALS -->
     <filter>
         <name>Controls Parking Brake Lever</name>
         <type>noise-spike</type>
-        <max-rate-of-change>2.5</max-rate-of-change>
+        <max-rate-of-change>1.0</max-rate-of-change>
         <enable>
             <condition>
                 <not>


### PR DESCRIPTION
Park brake lever should not translate and rotate at once but after another.

- See C182 ticket: https://github.com/HHS81/c182s/issues/596
- Footage: https://www.youtube.com/watch?v=Qz12zUlrZyk