### PR TITLE
Limit rudder-trim by a filter

### DIFF
--- a/Models/Interior/Panel/c172p-panel/c172p.xml
+++ b/Models/Interior/Panel/c172p-panel/c172p.xml
@@ -2234,6 +2234,7 @@
         </center>
     </animation>
 
+    <!-- Rudder trim is limited in ground-effects.xml in order to also limit custom keybinds -->
     <animation>
         <type>knob</type>
         <object-name>RudderTrimKnob</object-name>
@@ -2259,8 +2260,6 @@
                 <command>property-adjust</command>
                 <property>controls/flight/rudder-trim</property>
                 <factor>0.002</factor>
-                <min>-.18</min>
-                <max>.18</max>
                 <wrap>false</wrap>
             </binding>
             <binding>
@@ -2270,8 +2269,6 @@
                 <command>property-adjust</command>
                 <property>controls/flight/rudder-trim</property>
                 <factor>0.001</factor>
-                <min>-.18</min>
-                <max>.18</max>
                 <wrap>false</wrap>
             </binding>
         </action>

--- a/Systems/ground-effects.xml
+++ b/Systems/ground-effects.xml
@@ -1050,4 +1050,20 @@ Under the GPL. Used by shadows under ALS -->
         </output>
     </filter>
 
+    <!-- ================================================================== -->
+    <!-- Adjustments for flight controls                                    -->
+    <!-- ================================================================== -->
+    <filter>
+        <name>Limit range for rudder-trim</name>
+        <type>gain</type>
+        <input>
+            <property>/controls/flight/rudder-trim</property>
+        </input>
+        <output>
+            <property>/controls/flight/rudder-trim</property>
+        </output>
+        <min>-.18</min>
+        <max> .18</max>
+    </filter>
+
 </PropertyList>


### PR DESCRIPTION
A property rule filter limits the (optional) rudder-trim, so it is not overrideable by joystick/keyboard bindings anymore.

Fix #1515