### PR TITLE
Cockpit flight controls react to trim settings

### DIFF
--- a/c172p.xml
+++ b/c172p.xml
@@ -817,6 +817,20 @@
                     <min>-1</min>
                     <max>1</max>
                 </clipto>
+            </summer>
+            <summer name="Yoke Roll Sum">
+                <!--
+                Currently no aileron trim feedback to yoke. The C172 has an asymetrically mounted wing in order to
+                compensate for roll-forces in cruise. This is simulated by the aileron-trim prop.
+                Aileron _input_ (yoke) should be neutral, when the input device (joystick) is neutral.
+                Also, don't confuse with rudder-trim (which there is an option for).
+                For disuccsion see: https://github.com/c172p-team/c172p/issues/1471
+                -->
+                <input>fcs/aileron-cmd-norm-filtered</input>
+                <clipto>
+                    <min>-1</min>
+                    <max>1</max>
+                </clipto>
                 <output>/sim/model/c172p/cockpit/yoke-aileron</output>
             </summer>
 


### PR DESCRIPTION
Currently no aileron trim feedback to yoke. The C172 has an asymetrically mounted wing in order to compensate for roll-forces in cruise. This is simulated by the aileron-trim prop. Aileron _input_ (yoke) should be neutral, when the input device (joystick) is neutral. Also, don't confuse with rudder-trim (which there is an option for).

For disuccsion see: https://github.com/c172p-team/c172p/issues/1471
Fix #1471