### PR TITLE
Issue 1557

### DIFF
--- a/Models/c172p.xml
+++ b/Models/c172p.xml
@@ -2728,7 +2728,29 @@
                     <not><property>/devices/status/keyboard/alt</property></not>
                 </condition>
                 <command>property-adjust</command>
-                <property>controls/engines/current-engine/throttle</property>
+                <property>/controls/engines/engine[0]/throttle</property>
+                <factor>0.05</factor>
+                <min>0</min>
+                <max>1</max>
+                <wrap>0</wrap>
+            </binding>
+            <binding>
+                <condition>
+                    <not><property>/devices/status/keyboard/alt</property></not>
+                </condition>
+                <command>property-adjust</command>
+                <property>/controls/engines/engine[1]/throttle</property>
+                <factor>0.01</factor>
+                <min>0</min>
+                <max>1</max>
+                <wrap>0</wrap>
+            </binding>
+            <binding>
+                <condition>
+                    <property>/devices/status/keyboard/alt</property>
+                </condition>
+                <command>property-adjust</command>
+                <property>/controls/engines/engine[0]/throttle</property>
                 <factor>0.05</factor>
                 <min>0</min>
                 <max>1</max>
@@ -2739,7 +2761,7 @@
                     <property>/devices/status/keyboard/alt</property>
                 </condition>
                 <command>property-adjust</command>
-                <property>controls/engines/current-engine/throttle</property>
+                <property>/controls/engines/engine[1]/throttle</property>
                 <factor>0.01</factor>
                 <min>0</min>
                 <max>1</max>


### PR DESCRIPTION
Fixes #1557 

Using the mouse scroll wheel or left/middle mouse down to adjust the throttle was broken by some of the work in #1537. This merge fixes this issue.

It touches a small area the throttle model slider.
