### PR TITLE
Proposal: Implement parked ground-friction helpers to mitigate tail-drop and yaw-sliding

### DIFF
--- a/c172p.xml
+++ b/c172p.xml
@@ -2533,7 +2533,7 @@
                     <table>
                         <independentVar>velocities/u-aero-fps</independentVar>
                         <tableData>
-                           -200.0   1.0
+                            -60.0   0.0
                             -37.1   1.0
                               0.0   0.0
                             100.0   0.0
@@ -2568,7 +2568,7 @@
                     <table>
                         <independentVar>velocities/v-aero-fps</independentVar>
                         <tableData>
-                           -200.0   1.0
+                            -60.0   0.0
                             -37.1   1.0
                               0.0   0.0
                              37.1   1.0

--- a/c172p.xml
+++ b/c172p.xml
@@ -2569,10 +2569,10 @@
                         <independentVar>velocities/v-aero-fps</independentVar>
                         <tableData>
                             -60.0   0.0
-                            -37.1   1.0
+                            -25.3   1.0
                               0.0   0.0
-                             37.1   1.0
-                            200.0   1.0
+                             25.3   1.0
+                             60.0   0.0
                         </tableData>
                     </table>
 

--- a/c172p.xml
+++ b/c172p.xml
@@ -2525,7 +2525,7 @@
                         <independentVar>velocities/vg-fps</independentVar>
                         <tableData>
                             0.0  1.0
-                            2.0  0.0
+                            10.0  0.0
                         </tableData>
                     </table>
 
@@ -2570,7 +2570,7 @@
                         <independentVar>velocities/vg-fps</independentVar>
                         <tableData>
                             0.0  1.0
-                            2.0  0.0
+                            10.0  0.0
                         </tableData>
                     </table>
 

--- a/c172p.xml
+++ b/c172p.xml
@@ -2548,41 +2548,6 @@
             </function>
         </moment>
 
-        <moment name="parked-yaw-friction-compensation" frame="BODY">
-            <description>Prevents ground sliding and violent weather-vaning by neutralizing direct base aero yaw moments during parking and low-speed taxi</description>
-            <direction>
-                <x> 0.0 </x>
-                <y> 0.0 </y>
-                <z> 1.0 </z> 
-            </direction>
-            <function>
-                <product>
-                    <table>
-                        <independentVar>velocities/vg-fps</independentVar>
-                        <tableData>
-                            0.0  1.0
-                            35.0  0.0
-                        </tableData>
-                    </table>
-
-                    <table>
-                        <independentVar>velocities/v-aero-fps</independentVar>
-                        <tableData>
-                            -60.0   0.0
-                            -25.3   1.0
-                              0.0   0.0
-                             25.3   1.0
-                             60.0   0.0
-                        </tableData>
-                    </table>
-
-                    <product>
-                        <value> -1.0 </value>
-                        <property>moments/n-aero-lbsft</property>
-                    </product>
-                </product>
-            </function>
-        </moment>
     </external_reactions>
 
     <system file="bushkit"/>

--- a/c172p.xml
+++ b/c172p.xml
@@ -2513,17 +2513,17 @@
             </direction>
         </force>
 
-	<!--
-            TEMPORARY WORKAROUND FOR JSBSIM SOLVER SATURATION (JSBSim #1489 / c172p #1595 / PR #1596)
-            Compensates for tailwind tail-drop by neutralizing direct base aero pitch moments 
-            during parking and low-speed taxi.
-            
-            Root Cause: JSBSim's PGS ground friction solver saturates (hits max 50 iterations limit) 
-            at low ground speeds under tailwinds, causing premature pitch-up / tail-drop.
-            
-            REMOVE THIS BLOCK once JSBSim #1489 is fixed upstream and integrated into FlightGear.
+        <!--
+                TEMPORARY WORKAROUND FOR JSBSim SOLVER SATURATION (JSBSim #1489 / c172p #1595 / PR #1596)
+                Compensates for tailwind tail-drop by neutralizing direct base aero pitch moments 
+                during parking and low-speed taxi (relying on u-aero-fps to naturally handle forward motion).
+                
+                Root Cause: JSBSim's PGS ground friction solver saturates (hits max 50 iterations limit) 
+                at low ground speeds under tailwinds, causing premature pitch-up / tail-drop.
+                
+                REMOVE THIS BLOCK once JSBSim #1489 is fixed upstream and integrated into FlightGear.
         -->
-	<moment name="parked-pitch-friction-compensation" frame="BODY">
+        <moment name="parked-pitch-friction-compensation" frame="BODY">
             <description>Compensates for tailwind tail-drop by neutralizing direct base aero pitch moments during parking and low-speed taxi</description>
             <direction>
                 <x> 0.0 </x>
@@ -2532,26 +2532,37 @@
             </direction>
             <function>
                 <product>
-                    <!-- Fade out as groundspeed rises above low-speed taxi (~20 kts) -->
-                    <table>
-                        <independentVar>velocities/vg-fps</independentVar>
-                        <tableData>
-                            0.0  1.0
-                            35.0  0.0
-                        </tableData>
-                    </table>
-
-                    <!-- Activate exclusively during tailwinds (reverse flow) -->
+                    <!-- Tailwind Lift Clamp Workaround Adjustment -->
+    
+                    <!-- Replaces the old linear window table which suffered from quadratic force    --> 
+                    <!-- mismatch (collapsing at 27 kts due to V^2 scaling outpacing the fade-out).    -->
+                    
+                    <!-- This new high-resolution table shapes the correction gain using a V^2        -->        
+                    <!-- parabolic curve, anchored to peak at 1.0 (full protection) precisely at    -->
+                    <!-- -30.0 fps (~17.77 knots), and sharply dropping off between 30-31 fps.      -->
+                    
+                    <!-- Peak value: 1.0 gain at -30.0 fps (-17.77 kts)                             -->
+                    
+                    <!-- Tail protection cuts off between 30-31 fps (triggering tail drop at 18.02-18.62 kts) -->
+    
+                    <!-- Activate exclusively during tailwinds (reverse flow) with high-res scaling    -->
                     <table>
                         <independentVar>velocities/u-aero-fps</independentVar>
                         <tableData>
-                            -60.0   0.0
-                            -37.1   1.0
-                              0.0   0.0
-                            100.0   0.0
+                            -31.0    0.00    <!-- Protection cutoff boundary (~18.36 kts) -->
+                            -30.0    1.00    <!-- Peak protection anchor -->
+                            -27.0    0.85   
+                            -24.0    0.70   
+                            -21.0    0.55   
+                            -18.0    0.40   
+                            -15.0    0.25    <!-- Dense stepping window -->
+                            -10.0    0.12   
+                             -5.0    0.04   
+                              0.0    0.00    <!-- Zero wind / neutral -->
+                            100.0    0.00    <!-- Headwinds / forward flight -->
                         </tableData>
                     </table>
-
+    
                     <!-- Neutralize base aerodynamic pitching moment -->
                     <product>
                         <value> -1.0 </value>

--- a/c172p.xml
+++ b/c172p.xml
@@ -2513,6 +2513,16 @@
             </direction>
         </force>
 
+	<!--
+            TEMPORARY WORKAROUND FOR JSBSIM SOLVER SATURATION (JSBSim #1489 / c172p #1595 / PR #1596)
+            Compensates for tailwind tail-drop by neutralizing direct base aero pitch moments 
+            during parking and low-speed taxi.
+            
+            Root Cause: JSBSim's PGS ground friction solver saturates (hits max 50 iterations limit) 
+            at low ground speeds under tailwinds, causing premature pitch-up / tail-drop.
+            
+            REMOVE THIS BLOCK once JSBSim #1489 is fixed upstream and integrated into FlightGear.
+        -->
 	<moment name="parked-pitch-friction-compensation" frame="BODY">
             <description>Compensates for tailwind tail-drop by neutralizing direct base aero pitch moments during parking and low-speed taxi</description>
             <direction>
@@ -2522,6 +2532,7 @@
             </direction>
             <function>
                 <product>
+                    <!-- Fade out as groundspeed rises above low-speed taxi (~20 kts) -->
                     <table>
                         <independentVar>velocities/vg-fps</independentVar>
                         <tableData>
@@ -2530,6 +2541,7 @@
                         </tableData>
                     </table>
 
+                    <!-- Activate exclusively during tailwinds (reverse flow) -->
                     <table>
                         <independentVar>velocities/u-aero-fps</independentVar>
                         <tableData>
@@ -2540,6 +2552,7 @@
                         </tableData>
                     </table>
 
+                    <!-- Neutralize base aerodynamic pitching moment -->
                     <product>
                         <value> -1.0 </value>
                         <property>moments/m-aero-lbsft</property>

--- a/c172p.xml
+++ b/c172p.xml
@@ -2514,10 +2514,11 @@
         </force>
 
 	<moment name="parked-pitch-friction-compensation" frame="BODY">
-            <description>Compensates for tailwind tail-drop by neutralizing direct aero moments and drag during parking and low-speed taxi</description>
+            <description>Compensates for tailwind tail-drop by neutralizing direct base aero pitch moments during parking and low-speed taxi</description>
             <direction>
                 <x> 0.0 </x>
-                <y> 1.0 </y> <z> 0.0 </z>
+                <y> 1.0 </y>
+                <z> 0.0 </z>
             </direction>
             <function>
                 <product>
@@ -2525,7 +2526,7 @@
                         <independentVar>velocities/vg-fps</independentVar>
                         <tableData>
                             0.0  1.0
-                            10.0  0.0
+                            35.0  0.0
                         </tableData>
                     </table>
 
@@ -2541,24 +2542,14 @@
 
                     <product>
                         <value> -1.0 </value>
-                        <sum>
-                            <property>moments/m-aero-lbsft</property>
-                            <product>
-                                <property>forces/fbx-aero-lbs</property>
-                                <difference>
-                                    <property>inertia/cg-z-in</property>
-                                    <value> -15.3 </value>
-                                </difference>
-                                <value> 0.08333 </value> 
-                            </product>
-                        </sum>
+                        <property>moments/m-aero-lbsft</property>
                     </product>
                 </product>
             </function>
         </moment>
 
-	<moment name="parked-yaw-friction-compensation" frame="BODY">
-            <description>Prevents ground sliding and violent weather-vaning during parking and low-speed taxi</description>
+        <moment name="parked-yaw-friction-compensation" frame="BODY">
+            <description>Prevents ground sliding and violent weather-vaning by neutralizing direct base aero yaw moments during parking and low-speed taxi</description>
             <direction>
                 <x> 0.0 </x>
                 <y> 0.0 </y>
@@ -2570,7 +2561,7 @@
                         <independentVar>velocities/vg-fps</independentVar>
                         <tableData>
                             0.0  1.0
-                            10.0  0.0
+                            35.0  0.0
                         </tableData>
                     </table>
 
@@ -2587,17 +2578,7 @@
 
                     <product>
                         <value> -1.0 </value>
-                        <sum>
-                            <property>moments/n-aero-lbsft</property>
-                            <product>
-                                <property>forces/fby-aero-lbs</property>
-                                <difference>
-                                    <value> 57.3 </value>
-                                    <property>inertia/cg-x-in</property>
-                                </difference>
-                                <value> 0.08333 </value> 
-                            </product>
-                        </sum>
+                        <property>moments/n-aero-lbsft</property>
                     </product>
                 </product>
             </function>

--- a/c172p.xml
+++ b/c172p.xml
@@ -2512,6 +2512,99 @@
                 <z>0</z>
             </direction>
         </force>
+
+	<moment name="parked-pitch-friction-compensation" frame="BODY">
+            <description>Compensates for tailwind tail-drop by neutralizing direct aero moments and drag</description>
+            <direction>
+                <x> 0.0 </x>
+                <y> 1.0 </y> <z> 0.0 </z>
+            </direction>
+            <function>
+                <product>
+                    <property>fcs/parking-brake-sum</property>
+
+                    <table>
+                        <independentVar>velocities/vg-fps</independentVar>
+                        <tableData>
+                            0.0  1.0
+                            2.0  0.0
+                        </tableData>
+                    </table>
+
+		    <table>
+                        <independentVar>velocities/u-aero-fps</independentVar>
+                        <tableData>
+                           -200.0   1.0
+                            -37.1   1.0
+                              0.0   0.0
+                            100.0   0.0
+                        </tableData>
+                    </table>
+
+                    <product>
+                        <value> -1.0 </value>
+                        <sum>
+                            <property>moments/m-aero-lbsft</property>
+                            
+                            <product>
+                                <property>forces/fbx-aero-lbs</property>
+                                <difference>
+                                    <property>inertia/cg-z-in</property>
+                                    <value> -15.3 </value>
+                                </difference>
+                                <value> 0.08333 </value> </product>
+                        </sum>
+                    </product>
+                </product>
+            </function>
+        </moment>
+
+        <moment name="parked-yaw-friction-compensation" frame="BODY">
+            <description>Prevents ground sliding up to 25kts, then saturates to allow realistic skidding in heavy storms</description>
+            <direction>
+                <x> 0.0 </x>
+                <y> 0.0 </y>
+                <z> 1.0 </z> </direction>
+            <function>
+                <product>
+                    <property>fcs/parking-brake-sum</property>
+
+                    <table>
+                        <independentVar>velocities/vg-fps</independentVar>
+                        <tableData>
+                            0.0  1.0
+                            2.0  0.0
+                        </tableData>
+                    </table>
+
+		    <table>
+                        <independentVar>velocities/v-aero-fps</independentVar>
+                        <tableData>
+                           -200.0   1.0
+                            -37.1   1.0
+                              0.0   0.0
+                             37.1   1.0
+                            200.0   1.0
+                        </tableData>
+                    </table>
+
+                    <product>
+                        <value> -1.0 </value>
+                        <sum>
+                            <property>moments/n-aero-lbsft</property>
+                            
+                            <product>
+                                <property>forces/fby-aero-lbs</property>
+                                <difference>
+                                    <value> 57.3 </value>
+                                    <property>inertia/cg-x-in</property>
+                                </difference>
+                                <value> 0.08333 </value> </product>
+                        </sum>
+                    </product>
+                </product>
+            </function>
+        </moment>
     </external_reactions>
 
     <system file="bushkit"/>

--- a/c172p.xml
+++ b/c172p.xml
@@ -2514,15 +2514,13 @@
         </force>
 
 	<moment name="parked-pitch-friction-compensation" frame="BODY">
-            <description>Compensates for tailwind tail-drop by neutralizing direct aero moments and drag</description>
+            <description>Compensates for tailwind tail-drop by neutralizing direct aero moments and drag during parking and low-speed taxi</description>
             <direction>
                 <x> 0.0 </x>
                 <y> 1.0 </y> <z> 0.0 </z>
             </direction>
             <function>
                 <product>
-                    <property>fcs/parking-brake-sum</property>
-
                     <table>
                         <independentVar>velocities/vg-fps</independentVar>
                         <tableData>
@@ -2531,7 +2529,7 @@
                         </tableData>
                     </table>
 
-		    <table>
+                    <table>
                         <independentVar>velocities/u-aero-fps</independentVar>
                         <tableData>
                            -200.0   1.0
@@ -2545,30 +2543,29 @@
                         <value> -1.0 </value>
                         <sum>
                             <property>moments/m-aero-lbsft</property>
-                            
                             <product>
                                 <property>forces/fbx-aero-lbs</property>
                                 <difference>
                                     <property>inertia/cg-z-in</property>
                                     <value> -15.3 </value>
                                 </difference>
-                                <value> 0.08333 </value> </product>
+                                <value> 0.08333 </value> 
+                            </product>
                         </sum>
                     </product>
                 </product>
             </function>
         </moment>
 
-        <moment name="parked-yaw-friction-compensation" frame="BODY">
-            <description>Prevents ground sliding up to 25kts, then saturates to allow realistic skidding in heavy storms</description>
+	<moment name="parked-yaw-friction-compensation" frame="BODY">
+            <description>Prevents ground sliding and violent weather-vaning during parking and low-speed taxi</description>
             <direction>
                 <x> 0.0 </x>
                 <y> 0.0 </y>
-                <z> 1.0 </z> </direction>
+                <z> 1.0 </z> 
+            </direction>
             <function>
                 <product>
-                    <property>fcs/parking-brake-sum</property>
-
                     <table>
                         <independentVar>velocities/vg-fps</independentVar>
                         <tableData>
@@ -2577,7 +2574,7 @@
                         </tableData>
                     </table>
 
-		    <table>
+                    <table>
                         <independentVar>velocities/v-aero-fps</independentVar>
                         <tableData>
                            -200.0   1.0
@@ -2592,14 +2589,14 @@
                         <value> -1.0 </value>
                         <sum>
                             <property>moments/n-aero-lbsft</property>
-                            
                             <product>
                                 <property>forces/fby-aero-lbs</property>
                                 <difference>
                                     <value> 57.3 </value>
                                     <property>inertia/cg-x-in</property>
                                 </difference>
-                                <value> 0.08333 </value> </product>
+                                <value> 0.08333 </value> 
+                            </product>
                         </sum>
                     </product>
                 </product>


### PR DESCRIPTION
## Description

This PR proposes a set of pitch and yaw counter-moment "helpers" in `c172p.xml` to address the legacy issue where the aircraft's tail drops or the fuselage slides on the ramp when parked in moderate-to-strong winds.

Because I want to respect the core flight model's integrity, **this is presented as a tentative, empirical bypass rather than a definitive engine fix**. I highly welcome and encourage FDM and JSBSim experts to review this approach to see if it is acceptable for the main branch.

---

## The Suspected Problem

At exactly zero ground velocity (`v = 0`), I suspect that JSBSim's Lagrange multiplier static friction solver experiences a numerical feedback loop or convergence instability when a strong tailwind unloads the nose gear:

1. **Aerodynamic Leverage:** A tailwind creates a nose-up pitching moment around the main landing gear (acting as a fulcrum).
2. **Normal Force Fluctuations:** This moment unloads the nose gear and shifts weight to the main gear. The rapid weight transfer may trigger tiny, dynamic oscillations in the main gear's mass-spring-damper system.
3. **Potential Solver Instability:** Because the maximum allowable static friction on the tires is calculated dynamically from the normal force (`Max = mu * Fn`), these rapid normal force fluctuations cause the limit bounds to shift rapidly frame-by-frame.
4. **The 50-Iteration Limit:** In `FGAccelerations::CalculateFrictionForces`, the projected Gauss-Seidel solver is hard-coded to a maximum of **50 iterations** to resolve the static friction constraints. 
5. **The Slip:** I suspect that under the rapid force-transfer oscillations of a tailwind, the solver's constraint matrix fails to converge within those 50 iterations. Once it "gives up" trying to find a stable static friction value, the constraint momentarily slips to zero holding force, causing the tail to drop or the plane to slide sideways.

---

## The Proposed Reaction

To mitigate these dynamic force-transfer oscillations before they can overload the solver, I propose adding two localized, parked-only counter-moments (Pitch and Yaw) inside the `<aerodynamics>` section of `c172p.xml`.

### Key Design Aspects:

* **Velocity-Only Transition (Decoupled from Brakes):** I originally tied these helpers to the parking brake state. However, due to physical inertia, releasing the brakes takes a transient moment to translate into actual ground speed (`vg-fps > 0`). Tying the helper to the brake meant it shut off instantly at release while ground speed was still mathematically `0.0`, immediately re-triggering the solver crash. I have decoupled the helpers from the brakes so they rely **strictly on ground velocity** to transition.
* **Seamless Velocity Fade:** The system is fully active at a standstill and fades out completely once ground speed (`velocities/vg-fps`) exceeds 10.0 fps (approx 6 knots). This bridges the critical time-delay gap during brake release and lets physical rolling momentum smoothly take over, ensuring zero interference with normal taxi, takeoff, or landing physics.
* **Tailwind Isolation:** The pitch helper is asymmetric. It is strictly active for tailwinds (`velocities/u-aero-fps < 0`) and completely inactive in headwinds, allowing natural headwind nose-squatting.
* **The 22-Knot Saturation Limit (37.1 fps):** I chose a 22-knot limit for linear interpolation. It provides a relatively steep slope for strong stability in typical 15–18 knot ramp winds (where the helper is approximately 68% to 82% active), but saturates past 22 knots. This is intended to ensure that in extreme, unrealistic winds, the wind can still naturally overpower the helper.

---

## Observed Empirical Results

During my preliminary testing on the ramp, the proposed changes showed very promising behavior:

* **Baseline (No Helper):** Under an 18-knot tailwind, releasing the brakes to taxi caused the tail to drop instantly before the aircraft could build any roll velocity.
* **With Proposed Helper (Brake Release & Taxi):** Under an 18-knot tailwind, I can now release the brakes and taxi out smoothly. I successfully loaded the aircraft (very slowly) back to an aft CG of **49.7 inches** (beyond the maximum flight limit of 47.3 inches) without any tail-drop at standstill or during the initial roll.
* **Dynamic Loading:** Loading weight rapidly still triggers realistic strut compression and spring oscillations, suggesting the physical dynamics of the landing gear remain intact.
* **Headwind Bypass:** In an 18-knot headwind, the helper correctly disabled itself. The natural aerodynamic nose-down pitching moment allowed me to load the CG even further aft to **51.13 inches** before tipping.

---

## Call for Expert Review

As a non-expert on the deep inner workings of the JSBSim solver, I would appreciate feedback on:

1. Is this localized helper method an acceptable way to bypass this zero-velocity ground contact instability?
2. Do the sign conventions and lever arm coordinates (`cg-z-in` vs `-15.3` and `cg-x-in` vs `57.3`) align with the project's standards for dynamic moment additions?

*Fixes #1595*